### PR TITLE
[DLX] Multi Target wake and proxy

### DIFF
--- a/cmd/dlx/app/dlx.go
+++ b/cmd/dlx/app/dlx.go
@@ -18,7 +18,8 @@ func Run(kubeconfigPath string,
 	targetPathHeader string,
 	targetPort int,
 	listenAddress string,
-	resourceReadinessTimeout string) error {
+	resourceReadinessTimeout string,
+	multiTargetStrategy string) error {
 	pluginLoader, err := pluginloader.New()
 	if err != nil {
 		return errors.Wrap(err, "Failed to initialize plugin loader")
@@ -41,6 +42,7 @@ func Run(kubeconfigPath string,
 		ListenAddress:            listenAddress,
 		Namespace:                namespace,
 		ResourceReadinessTimeout: scalertypes.Duration{Duration: resourceReadinessTimeoutDuration},
+		MultiTargetStrategy:      scalertypes.MultiTargetStrategy(multiTargetStrategy),
 	}
 
 	// see if resource scaler wants to override the arguments

--- a/cmd/dlx/main.go
+++ b/cmd/dlx/main.go
@@ -18,6 +18,7 @@ func main() {
 	targetPort := flag.Int("target-port", 0, "Name of the header that holds information on target port")
 	listenAddress := flag.String("listen-address", ":8090", "Address to listen upon for http proxy")
 	resourceReadinessTimeout := flag.String("resource-readiness-timeout", "5m", "maximum wait time for the resource to be ready")
+	multiTargetStrategy := flag.String("multi-target-strategy", "random", "Strategy for selecting to which target to send the request")
 	flag.Parse()
 
 	*namespace = common.GetNamespace(*namespace)
@@ -28,7 +29,8 @@ func main() {
 		*targetPathHeader,
 		*targetPort,
 		*listenAddress,
-		*resourceReadinessTimeout); err != nil {
+		*resourceReadinessTimeout,
+		*multiTargetStrategy); err != nil {
 		errors.PrintErrorStack(os.Stderr, err, 5)
 
 		os.Exit(1)

--- a/pkg/dlx/dlx.go
+++ b/pkg/dlx/dlx.go
@@ -34,7 +34,8 @@ func NewDLX(parentLogger logger.Logger,
 		resourceScaler,
 		options.TargetNameHeader,
 		options.TargetPathHeader,
-		options.TargetPort)
+		options.TargetPort,
+		options.MultiTargetStrategy)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create handler")
 	}

--- a/pkg/dlx/handler.go
+++ b/pkg/dlx/handler.go
@@ -126,15 +126,17 @@ func (h *Handler) startResources(resourceNames []string) *ResourceStatusResult {
 	responseChannel := make(chan ResourceStatusResult, len(resourceNames))
 	defer close(responseChannel)
 
+	// Start all resources in separate go routines
 	for _, resourceName := range resourceNames {
 		h.resourceStarter.handleResourceStart(resourceName, responseChannel)
 	}
 
+	// Wait for all resources to finish starting
 	for range resourceNames {
 		statusResult := <-responseChannel
 
 		if statusResult.Error != nil {
-			h.logger.WarnWith("Failed to forward request to resource",
+			h.logger.WarnWith("Failed to start resource",
 				"resource", statusResult.ResourceName,
 				"err", errors.GetErrorStackString(statusResult.Error, 10))
 			return &statusResult

--- a/pkg/dlx/handler.go
+++ b/pkg/dlx/handler.go
@@ -2,13 +2,14 @@ package dlx
 
 import (
 	"fmt"
-	"github.com/v3io/scaler/pkg/scalertypes"
 	"math/rand"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/v3io/scaler/pkg/scalertypes"
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"

--- a/pkg/scalertypes/types.go
+++ b/pkg/scalertypes/types.go
@@ -22,6 +22,14 @@ type ResourceScalerConfig struct {
 	DLXOptions        DLXOptions
 }
 
+type MultiTargetStrategy string
+
+const (
+	MultiTargetStrategyRandom  MultiTargetStrategy = "random"
+	MultiTargetStrategyPrimary MultiTargetStrategy = "primary"
+	MultiTargetStrategyCanary  MultiTargetStrategy = "canary"
+)
+
 type DLXOptions struct {
 	Namespace string
 
@@ -31,6 +39,7 @@ type DLXOptions struct {
 	TargetPort               int
 	ListenAddress            string
 	ResourceReadinessTimeout Duration
+	MultiTargetStrategy      MultiTargetStrategy
 }
 
 type ResourceScaler interface {


### PR DESCRIPTION
If the `X-Nuclio-Target` contains multiple targets delimited by `,`, we wake both functions and send the invocation to either one depending on the strategy in the `DLXOptions`: `random`, `primary` or `canary`.