### PR TITLE
Sleep before reverse proxying requests

### DIFF
--- a/pkg/dlx/handler.go
+++ b/pkg/dlx/handler.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"time"
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
@@ -92,6 +93,8 @@ func (h *Handler) handleRequest(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	// let the function http trigger server some time before blasting him
+	time.Sleep(3 * time.Second)
 	h.logger.DebugWith("Creating reverse proxy", "targetURL", targetURL)
 	proxy := httputil.NewSingleHostReverseProxy(targetURL)
 	proxy.ServeHTTP(res, req)


### PR DESCRIPTION
This is a hotfix to allow function's http trigger server time before blasting him with requests.
