### PR TITLE
[DLX] Fix start resource function

### DIFF
--- a/pkg/dlx/resourcestarter.go
+++ b/pkg/dlx/resourcestarter.go
@@ -96,10 +96,7 @@ func (r *ResourceStarter) startResource(ctx context.Context, resourceSinkChannel
 	// to avoid closing a channel that is still being used
 	defer close(resourceReadyChannel)
 
-	waitResourceReadinessCtx, cancelFunc := context.WithCancel(ctx)
-	waitResourceReadinessCtx, cancelFuncTimeout := context.WithTimeout(waitResourceReadinessCtx, 15*time.Minute)
-
-	defer cancelFunc()
+	waitResourceReadinessCtx, cancelFuncTimeout := context.WithTimeout(ctx, 15*time.Minute)
 	defer cancelFuncTimeout()
 
 	go r.waitResourceReadiness(waitResourceReadinessCtx,
@@ -173,7 +170,8 @@ func (r *ResourceStarter) waitResourceReadiness(ctx context.Context,
 	if ctx.Err() != nil {
 		r.logger.WarnWithCtx(ctx,
 			"Wait resource readiness canceled",
-			"resourceName", resource.Name)
+			"resourceName", resource.Name,
+			"err", ctx.Err())
 		return
 	}
 	resourceReadyChannel <- err


### PR DESCRIPTION
Fixing bug where we try to write on closed channel on resource start:
<img width="1703" alt="image" src="https://github.com/v3io/scaler/assets/40743125/ef472d8a-3bf8-41e1-affd-e72c46a5eaaa">

After fix:
<img width="1724" alt="image" src="https://github.com/v3io/scaler/assets/40743125/439c06bc-3a2c-4810-8b45-5602b840001e">

Fixed it by moving the logic of cancellation timeout from [app-resource-scaler](https://github.com/v3io/app-resource-scaler/pull/31) to [scaler](https://github.com/v3io/scaler/pull/64)

https://github.com/v3io/app-resource-scaler/pull/31
https://iguazio.atlassian.net/browse/IG-22367
