### PR TITLE
[Framework] Add flow tests

### DIFF
--- a/pkg/ingresscache/ingresscache_test.go
+++ b/pkg/ingresscache/ingresscache_test.go
@@ -304,6 +304,16 @@ func (suite *IngressCacheTestSuite) TestAllThreeMainFunctionalitiesWithTheSameHo
 	suite.Require().Equal(flattenTestResult, map[string]map[string]FunctionTarget{
 		"example.com": {"/test/path": SingleTarget("test-function-name-2")},
 	})
+
+	// Delete the second function name and validate that the cache is empty
+	err = testIngressCache.Delete("example.com", "/test/path", "test-function-name-2")
+	suite.Require().NoError(err, "Expected no error when deleting the second function name")
+	getResult, err = testIngressCache.Get("example.com", "/test/path")
+	suite.Require().Error(err)
+	suite.Require().ErrorContains(err, "cache get failed: host does not exist")
+	suite.Require().Nil(getResult, "Expected no function names for empty cache")
+	flattenTestResult = suite.flattenIngressCache(testIngressCache)
+	suite.Require().Equal(flattenTestResult, map[string]map[string]FunctionTarget{})
 }
 
 func (suite *IngressCacheTestSuite) TestParallelSetForTheSameHostAndDifferentPath() {


### PR DESCRIPTION
This PR adds unit tests for the flow described in the related Jira ticket: https://iguazio.atlassian.net/browse/NUC-455 .
The tests ensure coverage of the newly implemented logic and validate its behavior under expected conditions.

In addition, this PR includes test coverage for the changes introduced in [v3io/scaler#72](https://github.com/v3io/scaler/pull/72), providing verification for that logic as well.

The unit tests failure are fixed in a separated PR - https://github.com/v3io/scaler/pull/72