### PR TITLE
[Framework] simplify cache interfaces

### DIFF
--- a/pkg/ingresscache/ingresscache.go
+++ b/pkg/ingresscache/ingresscache.go
@@ -39,7 +39,7 @@ func NewIngressCache(logger logger.Logger) *IngressCache {
 	}
 }
 
-func (ic *IngressCache) Set(host, path string, functions []string) error {
+func (ic *IngressCache) Set(host, path string, targets []string) error {
 	urlTree, exists := ic.syncMap.LoadOrStore(host, NewSafeTrie())
 
 	ingressHostsTree, ok := urlTree.(IngressHostsTree)
@@ -50,18 +50,18 @@ func (ic *IngressCache) Set(host, path string, functions []string) error {
 		return errors.Errorf("cache set failed: invalid path tree value: got: %t", urlTree)
 	}
 
-	if err := ingressHostsTree.Set(path, functions); err != nil {
+	if err := ingressHostsTree.Set(path, targets); err != nil {
 		if !exists {
 			ic.syncMap.Delete(host)
 		}
 
-		return errors.Wrap(err, "failed to set functions name in the ingress host tree")
+		return errors.Wrap(err, "failed to set targets name in the ingress host tree")
 	}
 
 	return nil
 }
 
-func (ic *IngressCache) Delete(host, path string, functions []string) error {
+func (ic *IngressCache) Delete(host, path string, targets []string) error {
 	urlTree, exists := ic.syncMap.Load(host)
 	if !exists {
 		ic.logger.Debug("cache delete: host not found")
@@ -73,8 +73,8 @@ func (ic *IngressCache) Delete(host, path string, functions []string) error {
 		return errors.Errorf("cache delete failed: invalid path tree value: got: %t", urlTree)
 	}
 
-	if err := ingressHostsTree.Delete(path, functions); err != nil {
-		return errors.Wrap(err, "failed to delete functions name from the ingress host tree")
+	if err := ingressHostsTree.Delete(path, targets); err != nil {
+		return errors.Wrap(err, "failed to delete targets name from the ingress host tree")
 	}
 
 	if ingressHostsTree.IsEmpty() {
@@ -100,7 +100,7 @@ func (ic *IngressCache) Get(host, path string) ([]string, error) {
 
 	result, err := ingressHostsTree.Get(path)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get the functions name from the ingress host tree")
+		return nil, errors.Wrap(err, "failed to get the targets name from the ingress host tree")
 	}
 
 	return result.ToSliceString(), nil

--- a/pkg/ingresscache/ingresscache.go
+++ b/pkg/ingresscache/ingresscache.go
@@ -39,7 +39,7 @@ func NewIngressCache(logger logger.Logger) *IngressCache {
 	}
 }
 
-func (ic *IngressCache) Set(host, path, function string) error {
+func (ic *IngressCache) Set(host, path string, functions []string) error {
 	urlTree, exists := ic.syncMap.LoadOrStore(host, NewSafeTrie())
 
 	ingressHostsTree, ok := urlTree.(IngressHostsTree)
@@ -50,18 +50,18 @@ func (ic *IngressCache) Set(host, path, function string) error {
 		return errors.Errorf("cache set failed: invalid path tree value: got: %t", urlTree)
 	}
 
-	if err := ingressHostsTree.Set(path, function); err != nil {
+	if err := ingressHostsTree.Set(path, functions); err != nil {
 		if !exists {
 			ic.syncMap.Delete(host)
 		}
 
-		return errors.Wrap(err, "failed to set function name in the ingress host tree")
+		return errors.Wrap(err, "failed to set functions name in the ingress host tree")
 	}
 
 	return nil
 }
 
-func (ic *IngressCache) Delete(host, path, function string) error {
+func (ic *IngressCache) Delete(host, path string, functions []string) error {
 	urlTree, exists := ic.syncMap.Load(host)
 	if !exists {
 		ic.logger.Debug("cache delete: host not found")
@@ -73,8 +73,8 @@ func (ic *IngressCache) Delete(host, path, function string) error {
 		return errors.Errorf("cache delete failed: invalid path tree value: got: %t", urlTree)
 	}
 
-	if err := ingressHostsTree.Delete(path, function); err != nil {
-		return errors.Wrap(err, "failed to delete function name from the ingress host tree")
+	if err := ingressHostsTree.Delete(path, functions); err != nil {
+		return errors.Wrap(err, "failed to delete functions name from the ingress host tree")
 	}
 
 	if ingressHostsTree.IsEmpty() {
@@ -100,7 +100,7 @@ func (ic *IngressCache) Get(host, path string) ([]string, error) {
 
 	result, err := ingressHostsTree.Get(path)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get the function name from the ingress host tree")
+		return nil, errors.Wrap(err, "failed to get the functions name from the ingress host tree")
 	}
 
 	return result.ToSliceString(), nil

--- a/pkg/ingresscache/ingresscache.go
+++ b/pkg/ingresscache/ingresscache.go
@@ -55,7 +55,7 @@ func (ic *IngressCache) Set(host, path string, targets []string) error {
 			ic.syncMap.Delete(host)
 		}
 
-		return errors.Wrap(err, "failed to set targets name in the ingress host tree")
+		return errors.Wrap(err, "failed to set targets in the ingress host tree")
 	}
 
 	return nil
@@ -74,7 +74,7 @@ func (ic *IngressCache) Delete(host, path string, targets []string) error {
 	}
 
 	if err := ingressHostsTree.Delete(path, targets); err != nil {
-		return errors.Wrap(err, "failed to delete targets name from the ingress host tree")
+		return errors.Wrap(err, "failed to delete targets from the ingress host tree")
 	}
 
 	if ingressHostsTree.IsEmpty() {
@@ -100,7 +100,7 @@ func (ic *IngressCache) Get(host, path string) ([]string, error) {
 
 	result, err := ingressHostsTree.Get(path)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get the targets name from the ingress host tree")
+		return nil, errors.Wrap(err, "failed to get the targets from the ingress host tree")
 	}
 
 	return result.ToSliceString(), nil

--- a/pkg/ingresscache/safetrie.go
+++ b/pkg/ingresscache/safetrie.go
@@ -40,7 +40,7 @@ func NewSafeTrie() *SafeTrie {
 	}
 }
 
-// Set adds a targets for a given path. If the path does not exist, it creates it
+// Set adds targets for a given path. If the path does not exist, it creates it
 func (st *SafeTrie) Set(path string, targets []string) error {
 	if path == "" {
 		return errors.New("path is empty")
@@ -58,7 +58,7 @@ func (st *SafeTrie) Set(path string, targets []string) error {
 	return nil
 }
 
-// Delete removes a targets from a path and cleans up the longest suffix of the path only used by that targets
+// Delete removes the targets from a path and cleans up the longest suffix of the path only used by these targets
 func (st *SafeTrie) Delete(path string, targets []string) error {
 	st.rwMutex.Lock()
 	defer st.rwMutex.Unlock()
@@ -74,13 +74,13 @@ func (st *SafeTrie) Delete(path string, targets []string) error {
 		return errors.Errorf("path value should be Target, got %T", pathValue)
 	}
 
-	requestTarget, err := st.NewTarget(targets)
+	targetToDelete, err := st.NewTarget(targets)
 	if err != nil {
 		return errors.Wrap(err, "failed to create Target for targets")
 	}
 
 	// If the Target instances do not match, nothing to delete
-	if !currentTarget.Equal(requestTarget) {
+	if !currentTarget.Equal(targetToDelete) {
 		return nil
 	}
 

--- a/pkg/ingresscache/safetrie_test.go
+++ b/pkg/ingresscache/safetrie_test.go
@@ -536,7 +536,7 @@ func (suite *PairTargetTestSuite) TestEqual() {
 			target:         PairTarget{"test-target1", "test-target3"},
 			expectedResult: false,
 		}, {
-			name:           "Equal empty targets name",
+			name:           "Equal empty PairTarget no match",
 			target:         PairTarget{},
 			expectedResult: false,
 		}, {

--- a/pkg/ingresscache/safetrie_test.go
+++ b/pkg/ingresscache/safetrie_test.go
@@ -31,8 +31,8 @@ type SafeTrieTestSuite struct {
 }
 
 type safeTrieFunctionArgs struct {
-	path     string
-	function string
+	path      string
+	functions []string
 }
 
 func (suite *SafeTrieTestSuite) TestPathTreeSet() {
@@ -48,82 +48,82 @@ func (suite *SafeTrieTestSuite) TestPathTreeSet() {
 			name: "simple set",
 			args: []safeTrieFunctionArgs{
 				{
-					path:     "/path/to/function",
-					function: "test-function",
+					path:      "/path/to/functions",
+					functions: []string{"test-functions"},
 				},
 			},
-			expectedResult: map[string]FunctionTarget{"/path/to/function": SingleTarget("test-function")},
+			expectedResult: map[string]FunctionTarget{"/path/to/functions": SingleTarget("test-functions")},
 		}, {
 			name: "idempotent test",
 			args: []safeTrieFunctionArgs{
 				{
-					path:     "/path/to/function",
-					function: "test-function",
+					path:      "/path/to/functions",
+					functions: []string{"test-functions"},
 				}, {
-					path:     "/path/to/function",
-					function: "test-function",
+					path:      "/path/to/functions",
+					functions: []string{"test-functions"},
 				},
 			},
-			expectedResult: map[string]FunctionTarget{"/path/to/function": SingleTarget("test-function")},
+			expectedResult: map[string]FunctionTarget{"/path/to/functions": SingleTarget("test-functions")},
 		}, {
-			name: "set twice the same path with a different function",
+			name: "set twice the same path with a different functions",
 			args: []safeTrieFunctionArgs{
 				{
-					path:     "/path/to/function",
-					function: "test-function",
+					path:      "/path/to/functions",
+					functions: []string{"test-functions"},
 				}, {
-					path:     "/path/to/function",
-					function: "test-function2",
+					path:      "/path/to/functions",
+					functions: []string{"test-function2"},
 				},
 			},
-			expectedResult: map[string]FunctionTarget{"/path/to/function": &CanaryTarget{[2]string{"test-function", "test-function2"}}},
+			expectedResult: map[string]FunctionTarget{"/path/to/functions": SingleTarget("test-function2")},
 		}, {
 			name: "set nested paths and different functions",
 			args: []safeTrieFunctionArgs{
 				{
-					path:     "/path/to/function",
-					function: "test-function",
+					path:      "/path/to/functions",
+					functions: []string{"test-functions"},
 				}, {
-					path:     "/path/to/function/nested",
-					function: "test-function2",
+					path:      "/path/to/functions/nested",
+					functions: []string{"test-function2"},
 				},
 			},
 			expectedResult: map[string]FunctionTarget{
-				"/path/to/function":        SingleTarget("test-function"),
-				"/path/to/function/nested": SingleTarget("test-function2"),
+				"/path/to/functions":        SingleTarget("test-functions"),
+				"/path/to/functions/nested": SingleTarget("test-function2"),
 			},
 		}, {
 			name: "set different paths and different functions",
 			args: []safeTrieFunctionArgs{
 				{
-					path:     "/path/to/function",
-					function: "test-function",
+					path:      "/path/to/functions",
+					functions: []string{"test-functions"},
 				}, {
-					path:     "/another/path/to/function/",
-					function: "test-function2",
+					path:      "/another/path/to/functions/",
+					functions: []string{"test-function2"},
 				},
 			},
 			expectedResult: map[string]FunctionTarget{
-				"/path/to/function":          SingleTarget("test-function"),
-				"/another/path/to/function/": SingleTarget("test-function2"),
+				"/path/to/functions":          SingleTarget("test-functions"),
+				"/another/path/to/functions/": SingleTarget("test-function2"),
 			},
 		}, {
-			name: "empty function name",
+			name: "empty functions name",
 			args: []safeTrieFunctionArgs{
 				{
-					path:     "/path/to/function",
-					function: "",
+					path:      "/path/to/functions",
+					functions: []string{},
 				},
 			},
 			expectedResult: map[string]FunctionTarget{},
 			expectError:    true,
-			errorMessage:   "function is empty",
+			errorMessage:   "failed to create FunctionTarget",
 		}, {
 			name: "empty path",
 			args: []safeTrieFunctionArgs{
 				{
-					path:     "",
-					function: "test-function",
+					path:      "",
+					functions: []string{"test-functions"},
 				},
 			},
 			expectedResult: map[string]FunctionTarget{},
@@ -133,23 +133,23 @@ func (suite *SafeTrieTestSuite) TestPathTreeSet() {
 			name: "double slash in path",
 			args: []safeTrieFunctionArgs{
 				{
-					path:     "///path/to/function",
-					function: "test-function",
+					path:      "///path/to/functions",
+					functions: []string{"test-functions"},
 				},
 			},
 			expectedResult: map[string]FunctionTarget{
-				"///path/to/function": SingleTarget("test-function"),
+				"///path/to/functions": SingleTarget("test-functions"),
 			},
 		}, {
 			name: "path starts without slash",
 			args: []safeTrieFunctionArgs{
 				{
-					path:     "path/to/function",
-					function: "test-function",
+					path:      "path/to/functions",
+					functions: []string{"test-functions"},
 				},
 			},
 			expectedResult: map[string]FunctionTarget{
-				"path/to/function": SingleTarget("test-function"),
+				"path/to/functions": SingleTarget("test-functions"),
 			},
 		}, {
 			name:           "lots of paths and functions",
@@ -157,35 +157,35 @@ func (suite *SafeTrieTestSuite) TestPathTreeSet() {
 			expectedResult: suite.generateExpectedResultMap(200),
 		}, {
 			name:           "path ends with slash",
-			args:           []safeTrieFunctionArgs{{path: "/path/to/function/", function: "test-function"}},
-			expectedResult: map[string]FunctionTarget{"/path/to/function/": SingleTarget("test-function")},
+			args:           []safeTrieFunctionArgs{{path: "/path/to/functions/", functions: []string{"test-functions"}}},
+			expectedResult: map[string]FunctionTarget{"/path/to/functions/": SingleTarget("test-functions")},
 		}, {
 			name:           "path with dots",
-			args:           []safeTrieFunctionArgs{{path: "/path/./to/./function/", function: "test-function"}},
-			expectedResult: map[string]FunctionTarget{"/path/./to/./function/": SingleTarget("test-function")},
+			args:           []safeTrieFunctionArgs{{path: "/path/./to/./functions/", functions: []string{"test-functions"}}},
+			expectedResult: map[string]FunctionTarget{"/path/./to/./functions/": SingleTarget("test-functions")},
 		}, {
 			name:           "upper case path",
-			args:           []safeTrieFunctionArgs{{path: "/PATH/TO/function", function: "test-function"}},
-			expectedResult: map[string]FunctionTarget{"/PATH/TO/function": SingleTarget("test-function")},
+			args:           []safeTrieFunctionArgs{{path: "/PATH/TO/functions", functions: []string{"test-functions"}}},
+			expectedResult: map[string]FunctionTarget{"/PATH/TO/functions": SingleTarget("test-functions")},
 		}, {
-			name: "upper case function name",
+			name: "upper case functions name",
 			args: []safeTrieFunctionArgs{
-				{path: "/path/to/function", function: "test-function"},
-				{path: "/path/to/function", function: "test-FUNCTION"},
+				{path: "/path/to/functions", functions: []string{"test-functions"}},
+				{path: "/path/to/functions", functions: []string{"test-functions", "test-FUNCTION"}},
 			},
-			expectedResult: map[string]FunctionTarget{"/path/to/function": &CanaryTarget{[2]string{"test-function", "test-FUNCTION"}}},
+			expectedResult: map[string]FunctionTarget{"/path/to/functions": &CanaryTarget{[2]string{"test-functions", "test-FUNCTION"}}},
 		}, {
 			name: "path with numbers and hyphens",
 			args: []safeTrieFunctionArgs{
-				{path: "/api/v1/user-data/123", function: "test-function"},
+				{path: "/api/v1/user-data/123", functions: []string{"test-functions"}},
 			},
-			expectedResult: map[string]FunctionTarget{"/api/v1/user-data/123": SingleTarget("test-function")},
+			expectedResult: map[string]FunctionTarget{"/api/v1/user-data/123": SingleTarget("test-functions")},
 		},
 	} {
 		suite.Run(testCase.name, func() {
 			testSafeTrie := suite.generateSafeTrieForTest([]safeTrieFunctionArgs{})
 			for _, setArgs := range testCase.args {
-				err := testSafeTrie.Set(setArgs.path, setArgs.function)
+				err := testSafeTrie.Set(setArgs.path, setArgs.functions)
 				if testCase.expectError {
 					suite.Require().Error(err)
 					suite.Require().ErrorContains(err, testCase.errorMessage)
@@ -202,13 +202,12 @@ func (suite *SafeTrieTestSuite) TestPathTreeSet() {
 func (suite *SafeTrieTestSuite) TestPathTreeGet() {
 	suite.T().Parallel()
 	initialStateGetTest := []safeTrieFunctionArgs{
-		{"/", "test-function"},
-		{"/path/to/function1", "test-function1"},
-		{"/path/to/function1/nested", "test-function2"},
-		{"/path/./to/./function/", "test-function1"},
-		{"path//to//function/", "test-function1"},
-		{"/path/to/multiple/functions", "test-function1"},
-		{"/path/to/multiple/functions", "test-function2"},
+		{"/", []string{"test-functions"}},
+		{"/path/to/function1", []string{"test-function1"}},
+		{"/path/to/function1/nested", []string{"test-function2"}},
+		{"/path/./to/./functions/", []string{"test-function1"}},
+		{"path//to//functions/", []string{"test-function1"}},
+		{"/path/to/multiple/functions", []string{"test-function1", "test-function2"}},
 	}
 	for _, testCase := range []struct {
 		name           string
@@ -220,7 +219,7 @@ func (suite *SafeTrieTestSuite) TestPathTreeGet() {
 		{
 			name:           "get root path",
 			path:           "/",
-			expectedResult: SingleTarget("test-function"),
+			expectedResult: SingleTarget("test-functions"),
 		}, {
 			name:           "get regular path",
 			path:           "/path/to/function1",
@@ -244,11 +243,11 @@ func (suite *SafeTrieTestSuite) TestPathTreeGet() {
 			expectedResult: SingleTarget("test-function1"),
 		}, {
 			name:           "get path with dots",
-			path:           "/path/./to/./function/",
+			path:           "/path/./to/./functions/",
 			expectedResult: SingleTarget("test-function1"),
 		}, {
 			name:           "get path with slash",
-			path:           "path//to//function/",
+			path:           "path//to//functions/",
 			expectedResult: SingleTarget("test-function1"),
 		}, {
 			name:           "get multiple functions for the same path",
@@ -282,58 +281,56 @@ func (suite *SafeTrieTestSuite) TestPathTreeDelete() {
 		{
 			name: "delete a path and validate that nested path is still there",
 			initialState: []safeTrieFunctionArgs{
-				{"/path/to/function1", "test-function1"},
-				{"/path/to/function1/nested", "test-function2"},
+				{"/path/to/function1", []string{"test-function1"}},
+				{"/path/to/function1/nested", []string{"test-function2"}},
 			},
-			deleteArgs: safeTrieFunctionArgs{"/path/to/function1", "test-function1"},
+			deleteArgs: safeTrieFunctionArgs{"/path/to/function1", []string{"test-function1"}},
 			expectedResult: map[string]FunctionTarget{
 				"/path/to/function1/nested": SingleTarget("test-function2"),
 			},
 		}, {
-			name: "delete a function from multiple values and validate that the other function is still there",
+			name: "delete a functions from multiple values shouldn't do anything, validate that the functions is still there",
 			initialState: []safeTrieFunctionArgs{
-				{"/path/to/multiple/functions", "test-function1"},
-				{"/path/to/multiple/functions", "test-function2"},
+				{"/path/to/multiple/functions", []string{"test-function1", "test-function2"}},
 			},
-			deleteArgs: safeTrieFunctionArgs{"/path/to/multiple/functions", "test-function1"},
+			deleteArgs: safeTrieFunctionArgs{"/path/to/multiple/functions", []string{"test-function1"}},
 			expectedResult: map[string]FunctionTarget{
-				"/path/to/multiple/functions": SingleTarget("test-function2"),
+				"/path/to/multiple/functions": &CanaryTarget{[2]string{"test-function1", "test-function2"}},
 			},
 		}, {
-			name: "delete function that does not exist in the path",
+			name: "delete functions that does not exist in the path",
 			initialState: []safeTrieFunctionArgs{
-				{"/path/to/function1", "test-function1"},
+				{"/path/to/function1", []string{"test-function1"}},
 			},
-			deleteArgs: safeTrieFunctionArgs{"/path/to/function1", "test-function2"},
+			deleteArgs: safeTrieFunctionArgs{"/path/to/function1", []string{"test-function2"}},
 			expectedResult: map[string]FunctionTarget{
 				"/path/to/function1": SingleTarget("test-function1"),
 			},
 		}, {
-			name: "delete function that does not exist in multiple value path",
+			name: "delete functions that does not exist in multiple value path",
 			initialState: []safeTrieFunctionArgs{
-				{"/path/to/functions", "test-function1"},
-				{"/path/to/functions", "test-function2"},
+				{"/path/to/functions", []string{"test-function1", "test-function2"}},
 			},
-			deleteArgs: safeTrieFunctionArgs{"/path/to/functions", "test-not-existing-function"},
+			deleteArgs: safeTrieFunctionArgs{"/path/to/functions", []string{"test-not-existing-functions"}},
 			expectedResult: map[string]FunctionTarget{
 				"/path/to/functions": &CanaryTarget{[2]string{"test-function1", "test-function2"}},
 			},
 		}, {
 			name: "delete not exist path",
 			initialState: []safeTrieFunctionArgs{
-				{"/path/to/function1", "test-function1"},
+				{"/path/to/function1", []string{"test-function1"}},
 			},
-			deleteArgs: safeTrieFunctionArgs{"/path/to/function1/nested", "test-function2"},
+			deleteArgs: safeTrieFunctionArgs{"/path/to/function1/nested", []string{"test-function2"}},
 			expectedResult: map[string]FunctionTarget{
 				"/path/to/function1": SingleTarget("test-function1"),
 			},
 		}, {
 			name: "delete path with suffix that does not exist",
 			initialState: []safeTrieFunctionArgs{
-				{"/path/to/function1", "test-function1"},
-				{"/path/to/function1/nested", "test-function2"},
+				{"/path/to/function1", []string{"test-function1"}},
+				{"/path/to/function1/nested", []string{"test-function2"}},
 			},
-			deleteArgs: safeTrieFunctionArgs{"/path/to/function1/path/suffix", "test-function1"},
+			deleteArgs: safeTrieFunctionArgs{"/path/to/function1/path/suffix", []string{"test-function1"}},
 			expectedResult: map[string]FunctionTarget{
 				"/path/to/function1":        SingleTarget("test-function1"),
 				"/path/to/function1/nested": SingleTarget("test-function2"),
@@ -343,7 +340,7 @@ func (suite *SafeTrieTestSuite) TestPathTreeDelete() {
 		suite.Run(testCase.name, func() {
 			testSafeTrie := suite.generateSafeTrieForTest(testCase.initialState)
 
-			err := testSafeTrie.Delete(testCase.deleteArgs.path, testCase.deleteArgs.function)
+			err := testSafeTrie.Delete(testCase.deleteArgs.path, testCase.deleteArgs.functions)
 			if testCase.expectError {
 				suite.Require().Error(err)
 				suite.Require().ErrorContains(err, testCase.errorMessage)
@@ -372,7 +369,7 @@ func (suite *SafeTrieTestSuite) TestPathTreeIsEmpty() {
 			name:           "is empty with not empty trie",
 			expectedResult: false,
 			initialState: []safeTrieFunctionArgs{
-				{"/test/path/", "test-function1"},
+				{"/test/path/", []string{"test-function1"}},
 			},
 		},
 	} {
@@ -388,11 +385,11 @@ func (suite *SafeTrieTestSuite) TestPathTreeIsEmpty() {
 // --- SafeTrieTestSuite suite methods ---
 
 // flattenSafeTrie converts a PathTrie into a map[string]FunctionTarget
-// This function is not part of the SafeTrieTestSuite because it is also in use in IngressCacheTestSuite
+// This functions is not part of the SafeTrieTestSuite because it is also in use in IngressCacheTestSuite
 func flattenSafeTrie(st *SafeTrie) (map[string]FunctionTarget, error) {
 	resultMap := make(map[string]FunctionTarget)
 	err := st.pathTrie.Walk(func(key string, value interface{}) error {
-		// The Walk function iterates over all nodes.
+		// The Walk functions iterates over all nodes.
 		// Only store key-value pairs where a non-nil value has been explicitly 'Put'.
 		// If a node exists as an internal prefix (e.g., "/a" for "/a/b"), its 'value' will be nil.
 		// We only care about the values that were actually stored.
@@ -414,9 +411,9 @@ func flattenSafeTrie(st *SafeTrie) (map[string]FunctionTarget, error) {
 func (suite *SafeTrieTestSuite) generatePathsAndFunctions(num int) []safeTrieFunctionArgs {
 	args := make([]safeTrieFunctionArgs, num)
 	for i := 0; i < num; i++ {
-		path := fmt.Sprintf("/path/to/function/%d", i)
-		function := fmt.Sprintf("function-%d", i)
-		args[i] = safeTrieFunctionArgs{path: path, function: function}
+		path := fmt.Sprintf("/path/to/functions/%d", i)
+		functions := []string{fmt.Sprintf("functions-%d", i)}
+		args[i] = safeTrieFunctionArgs{path: path, functions: functions}
 	}
 	return args
 }
@@ -425,7 +422,7 @@ func (suite *SafeTrieTestSuite) generateExpectedResultMap(num int) map[string]Fu
 	expectedResult := make(map[string]FunctionTarget)
 	args := suite.generatePathsAndFunctions(num)
 	for i := 0; i < num; i++ {
-		expectedResult[args[i].path] = SingleTarget(args[i].function)
+		expectedResult[args[i].path] = SingleTarget(args[i].functions[0])
 	}
 	return expectedResult
 }
@@ -437,7 +434,7 @@ func (suite *SafeTrieTestSuite) generateSafeTrieForTest(initialSafeTrieState []s
 
 	// set path tree with the provided required state
 	for _, args := range initialSafeTrieState {
-		err = safeTrie.Set(args.path, args.function)
+		err = safeTrie.Set(args.path, args.functions)
 		suite.Require().NoError(err)
 	}
 
@@ -453,27 +450,27 @@ type SingleTargetTestSuite struct {
 	suite.Suite
 }
 
-func (suite *SingleTargetTestSuite) TestContains() {
+func (suite *SingleTargetTestSuite) TestEqual() {
 	testCases := []struct {
 		name           string
-		functionName   string
+		functionTarget FunctionTarget
 		expectedResult bool
 	}{
 		{
-			name:           "Contains exact match",
-			functionName:   "myFunction",
+			name:           "Equal exact match",
+			functionTarget: SingleTarget("myFunction"),
 			expectedResult: true,
 		}, {
-			name:           "Contains no match",
-			functionName:   "otherFunction",
+			name:           "Equal no match",
+			functionTarget: SingleTarget("otherFunction"),
 			expectedResult: false,
 		}, {
-			name:           "Contains empty function name no match",
-			functionName:   "",
+			name:           "Equal empty functions name no match",
+			functionTarget: SingleTarget(""),
 			expectedResult: false,
 		}, {
-			name:           "Contains case sensitive",
-			functionName:   "MYFUNCTION",
+			name:           "Equal canary no match",
+			functionTarget: CanaryTarget{functionNames: [2]string{}},
 			expectedResult: false,
 		},
 	}
@@ -481,72 +478,7 @@ func (suite *SingleTargetTestSuite) TestContains() {
 	for _, testCase := range testCases {
 		suite.Run(testCase.name, func() {
 			testSingleFunctionName := SingleTarget("myFunction")
-			result := testSingleFunctionName.Contains(testCase.functionName)
-			suite.Equal(testCase.expectedResult, result)
-		})
-	}
-}
-
-func (suite *SingleTargetTestSuite) TestRemoveFunctionName() {
-	testCases := []struct {
-		name           string
-		functionName   string
-		expectedResult FunctionTarget
-		expectError    bool
-		errorMessage   string
-	}{
-		{
-			name:           "RemoveExistingFunction",
-			functionName:   "test-function1",
-			expectedResult: nil,
-			expectError:    true,
-			errorMessage:   "cannot remove function name from SingleTarget, it only contains one function name",
-		},
-		{
-			name:           "RemoveNonExistingFunction",
-			functionName:   "otherFunction",
-			expectedResult: SingleTarget("test-function1"),
-		},
-	}
-
-	for _, testCase := range testCases {
-		suite.Run(testCase.name, func() {
-			testSingleFunctionName := SingleTarget("test-function1")
-			result, err := testSingleFunctionName.Delete(testCase.functionName)
-			if testCase.expectError {
-				suite.Require().Error(err)
-				suite.Require().ErrorContains(err, testCase.errorMessage)
-				suite.Nil(result)
-			} else {
-				suite.Equal(testCase.expectedResult, result)
-			}
-		})
-	}
-}
-
-func (suite *SingleTargetTestSuite) TestAddFunctionName() {
-	testCases := []struct {
-		name           string
-		functionName   string
-		expectedResult FunctionTarget
-	}{
-		{
-			name:           "Add same function name",
-			functionName:   "test-function1",
-			expectedResult: SingleTarget("test-function1"),
-		}, {
-			name:           "Add function name",
-			functionName:   "test-function2",
-			expectedResult: &CanaryTarget{[2]string{"test-function1", "test-function2"}},
-		},
-	}
-
-	for _, testCase := range testCases {
-		suite.Run(testCase.name, func() {
-			testSingleFunctionName := SingleTarget("test-function1")
-			result, err := testSingleFunctionName.Add(testCase.functionName)
-			suite.Require().NoError(err)
-			suite.Require().NotNil(result)
+			result := testSingleFunctionName.Equal(testCase.functionTarget)
 			suite.Equal(testCase.expectedResult, result)
 		})
 	}
@@ -579,25 +511,6 @@ func (suite *SingleTargetTestSuite) TestToSliceString() {
 	}
 }
 
-func (suite *SingleTargetTestSuite) TestIsSingleFunctionName() {
-	testCases := []struct {
-		name               string
-		singleFunctionName SingleTarget
-	}{
-		{
-			name:               "IsSingleFunctionNameTrue",
-			singleFunctionName: SingleTarget("isSingleFunctionNameFunction"),
-		},
-	}
-
-	for _, testCase := range testCases {
-		suite.Run(testCase.name, func() {
-			result := testCase.singleFunctionName.IsSingle()
-			suite.Require().True(result)
-		})
-	}
-}
-
 // TestSingleFunctionNameTestSuite runs the test suite
 func TestSingleFunctionNameTestSuite(t *testing.T) {
 	suite.Run(t, new(SingleTargetTestSuite))
@@ -608,27 +521,31 @@ type CanaryTargetTestSuite struct {
 	suite.Suite
 }
 
-func (suite *CanaryTargetTestSuite) TestContains() {
+func (suite *CanaryTargetTestSuite) TestEqual() {
 	testCases := []struct {
 		name           string
-		functionName   string
+		functionTarget FunctionTarget
 		expectedResult bool
 	}{
 		{
-			name:           "Contains match",
-			functionName:   "test-function1",
+			name:           "Equal match",
+			functionTarget: &CanaryTarget{[2]string{"test-function1", "test-function2"}},
 			expectedResult: true,
 		}, {
-			name:           "Contains no match",
-			functionName:   "test-function3",
+			name:           "Equal no match",
+			functionTarget: &CanaryTarget{[2]string{"test-function1", "test-function3"}},
 			expectedResult: false,
 		}, {
-			name:           "Contains empty function name",
-			functionName:   "",
+			name:           "Equal empty functions name",
+			functionTarget: &CanaryTarget{[2]string{}},
 			expectedResult: false,
 		}, {
-			name:           "Contains case sensitive",
-			functionName:   "TEST-function1",
+			name:           "Equal case sensitive",
+			functionTarget: &CanaryTarget{[2]string{"TEST-function1", "test-function2"}},
+			expectedResult: false,
+		}, {
+			name:           "Equal with single functions",
+			functionTarget: SingleTarget("test-function1"),
 			expectedResult: false,
 		},
 	}
@@ -636,72 +553,8 @@ func (suite *CanaryTargetTestSuite) TestContains() {
 	for _, testCase := range testCases {
 		suite.Run(testCase.name, func() {
 			testCanaryFunctionNames := &CanaryTarget{[2]string{"test-function1", "test-function2"}}
-			result := testCanaryFunctionNames.Contains(testCase.functionName)
+			result := testCanaryFunctionNames.Equal(testCase.functionTarget)
 			suite.Equal(testCase.expectedResult, result)
-		})
-	}
-}
-
-func (suite *CanaryTargetTestSuite) TestRemoveFunctionName() {
-	testCases := []struct {
-		name           string
-		functionName   string
-		expectedResult FunctionTarget
-	}{
-		{
-			name:           "RemoveExistingFunction",
-			functionName:   "test-function1",
-			expectedResult: SingleTarget("test-function2"),
-		}, {
-			name:           "RemoveNotExistingFunction",
-			functionName:   "test-function3",
-			expectedResult: &CanaryTarget{[2]string{"test-function1", "test-function2"}},
-		},
-	}
-
-	for _, testCase := range testCases {
-		suite.Run(testCase.name, func() {
-			testCanaryFunctionNames := &CanaryTarget{[2]string{"test-function1", "test-function2"}}
-			result, err := testCanaryFunctionNames.Delete(testCase.functionName)
-			suite.Require().NoError(err)
-			suite.Require().Equal(testCase.expectedResult, result)
-		})
-	}
-}
-
-func (suite *CanaryTargetTestSuite) TestAddFunctionName() {
-	testCases := []struct {
-		name           string
-		functionName   string
-		expectedResult FunctionTarget
-		expectError    bool
-		errorMessage   string
-	}{
-		{
-			name:           "Add same function name",
-			functionName:   "test-function1",
-			expectedResult: &CanaryTarget{[2]string{"test-function1", "test-function2"}},
-		}, {
-			name:           "Add distinct function name to a CanaryTarget",
-			functionName:   "test-function3",
-			expectedResult: &CanaryTarget{[2]string{"test-function1", "test-function2"}},
-			expectError:    true,
-			errorMessage:   "cannot add function name to CanaryTarget, it already contains two function names",
-		},
-	}
-
-	for _, testCase := range testCases {
-		suite.Run(testCase.name, func() {
-			testCanaryFunctionNames := &CanaryTarget{[2]string{"test-function1", "test-function2"}}
-			result, err := testCanaryFunctionNames.Add(testCase.functionName)
-			if testCase.expectError {
-				suite.Require().Error(err)
-				suite.Require().ErrorContains(err, testCase.errorMessage)
-				suite.Equal(testCase.expectedResult, result)
-			} else {
-				suite.Require().NoError(err)
-				suite.Equal(testCase.expectedResult, result)
-			}
 		})
 	}
 }
@@ -728,24 +581,6 @@ func (suite *CanaryTargetTestSuite) TestToSliceString() {
 			testCanaryFunctionNames := &CanaryTarget{testCase.canaryTarget}
 			result := testCanaryFunctionNames.ToSliceString()
 			suite.Equal(testCase.expectedResult, result)
-		})
-	}
-}
-
-func (suite *CanaryTargetTestSuite) TestIsSingleFunctionName() {
-	testCases := []struct {
-		name string
-	}{
-		{
-			name: "IsSingleFunctionNameTrue",
-		},
-	}
-
-	for _, testCase := range testCases {
-		suite.Run(testCase.name, func() {
-			testCanaryFunctionNames := &CanaryTarget{[2]string{"test-function1", "test-function2"}}
-			result := testCanaryFunctionNames.IsSingle()
-			suite.Require().False(result)
 		})
 	}
 }

--- a/pkg/ingresscache/safetrie_test.go
+++ b/pkg/ingresscache/safetrie_test.go
@@ -30,162 +30,162 @@ type SafeTrieTestSuite struct {
 	suite.Suite
 }
 
-type safeTrieFunctionArgs struct {
-	path      string
-	functions []string
+type safeTrieTestArgs struct {
+	path    string
+	targets []string
 }
 
 func (suite *SafeTrieTestSuite) TestPathTreeSet() {
 	suite.T().Parallel()
 	for _, testCase := range []struct {
 		name           string
-		args           []safeTrieFunctionArgs
-		expectedResult map[string]FunctionTarget
+		args           []safeTrieTestArgs
+		expectedResult map[string]Target
 		expectError    bool
 		errorMessage   string
 	}{
 		{
 			name: "simple set",
-			args: []safeTrieFunctionArgs{
+			args: []safeTrieTestArgs{
 				{
-					path:      "/path/to/functions",
-					functions: []string{"test-functions"},
+					path:    "/path/to/targets",
+					targets: []string{"test-target"},
 				},
 			},
-			expectedResult: map[string]FunctionTarget{"/path/to/functions": SingleTarget("test-functions")},
+			expectedResult: map[string]Target{"/path/to/targets": SingleTarget("test-target")},
 		}, {
 			name: "idempotent test",
-			args: []safeTrieFunctionArgs{
+			args: []safeTrieTestArgs{
 				{
-					path:      "/path/to/functions",
-					functions: []string{"test-functions"},
+					path:    "/path/to/targets",
+					targets: []string{"test-target"},
 				}, {
-					path:      "/path/to/functions",
-					functions: []string{"test-functions"},
+					path:    "/path/to/targets",
+					targets: []string{"test-target"},
 				},
 			},
-			expectedResult: map[string]FunctionTarget{"/path/to/functions": SingleTarget("test-functions")},
+			expectedResult: map[string]Target{"/path/to/targets": SingleTarget("test-target")},
 		}, {
-			name: "set twice the same path with a different functions",
-			args: []safeTrieFunctionArgs{
+			name: "set twice the same path with a different targets",
+			args: []safeTrieTestArgs{
 				{
-					path:      "/path/to/functions",
-					functions: []string{"test-functions"},
+					path:    "/path/to/targets",
+					targets: []string{"test-target"},
 				}, {
-					path:      "/path/to/functions",
-					functions: []string{"test-function2"},
+					path:    "/path/to/targets",
+					targets: []string{"test-target2"},
 				},
 			},
-			expectedResult: map[string]FunctionTarget{"/path/to/functions": SingleTarget("test-function2")},
+			expectedResult: map[string]Target{"/path/to/targets": SingleTarget("test-target2")},
 		}, {
-			name: "set nested paths and different functions",
-			args: []safeTrieFunctionArgs{
+			name: "set nested paths and different targets",
+			args: []safeTrieTestArgs{
 				{
-					path:      "/path/to/functions",
-					functions: []string{"test-functions"},
+					path:    "/path/to/targets",
+					targets: []string{"test-target"},
 				}, {
-					path:      "/path/to/functions/nested",
-					functions: []string{"test-function2"},
+					path:    "/path/to/targets/nested",
+					targets: []string{"test-target2"},
 				},
 			},
-			expectedResult: map[string]FunctionTarget{
-				"/path/to/functions":        SingleTarget("test-functions"),
-				"/path/to/functions/nested": SingleTarget("test-function2"),
-			},
-		}, {
-			name: "set different paths and different functions",
-			args: []safeTrieFunctionArgs{
-				{
-					path:      "/path/to/functions",
-					functions: []string{"test-functions"},
-				}, {
-					path:      "/another/path/to/functions/",
-					functions: []string{"test-function2"},
-				},
-			},
-			expectedResult: map[string]FunctionTarget{
-				"/path/to/functions":          SingleTarget("test-functions"),
-				"/another/path/to/functions/": SingleTarget("test-function2"),
+			expectedResult: map[string]Target{
+				"/path/to/targets":        SingleTarget("test-target"),
+				"/path/to/targets/nested": SingleTarget("test-target2"),
 			},
 		}, {
-			name: "empty functions name",
-			args: []safeTrieFunctionArgs{
+			name: "set different paths and different targets",
+			args: []safeTrieTestArgs{
 				{
-					path:      "/path/to/functions",
-					functions: []string{},
+					path:    "/path/to/targets",
+					targets: []string{"test-target"},
+				}, {
+					path:    "/another/path/to/targets/",
+					targets: []string{"test-target2"},
 				},
 			},
-			expectedResult: map[string]FunctionTarget{},
+			expectedResult: map[string]Target{
+				"/path/to/targets":          SingleTarget("test-target"),
+				"/another/path/to/targets/": SingleTarget("test-target2"),
+			},
+		}, {
+			name: "empty targets name",
+			args: []safeTrieTestArgs{
+				{
+					path:    "/path/to/targets",
+					targets: []string{},
+				},
+			},
+			expectedResult: map[string]Target{},
 			expectError:    true,
-			errorMessage:   "failed to create FunctionTarget",
+			errorMessage:   "failed to create Target",
 		}, {
 			name: "empty path",
-			args: []safeTrieFunctionArgs{
+			args: []safeTrieTestArgs{
 				{
-					path:      "",
-					functions: []string{"test-functions"},
+					path:    "",
+					targets: []string{"test-target"},
 				},
 			},
-			expectedResult: map[string]FunctionTarget{},
+			expectedResult: map[string]Target{},
 			expectError:    true,
 			errorMessage:   "path is empty",
 		}, {
 			name: "double slash in path",
-			args: []safeTrieFunctionArgs{
+			args: []safeTrieTestArgs{
 				{
-					path:      "///path/to/functions",
-					functions: []string{"test-functions"},
+					path:    "///path/to/targets",
+					targets: []string{"test-target"},
 				},
 			},
-			expectedResult: map[string]FunctionTarget{
-				"///path/to/functions": SingleTarget("test-functions"),
+			expectedResult: map[string]Target{
+				"///path/to/targets": SingleTarget("test-target"),
 			},
 		}, {
 			name: "path starts without slash",
-			args: []safeTrieFunctionArgs{
+			args: []safeTrieTestArgs{
 				{
-					path:      "path/to/functions",
-					functions: []string{"test-functions"},
+					path:    "path/to/targets",
+					targets: []string{"test-target"},
 				},
 			},
-			expectedResult: map[string]FunctionTarget{
-				"path/to/functions": SingleTarget("test-functions"),
+			expectedResult: map[string]Target{
+				"path/to/targets": SingleTarget("test-target"),
 			},
 		}, {
-			name:           "lots of paths and functions",
-			args:           suite.generatePathsAndFunctions(200),
+			name:           "lots of paths and targets",
+			args:           suite.generatePathsAndTargets(200),
 			expectedResult: suite.generateExpectedResultMap(200),
 		}, {
 			name:           "path ends with slash",
-			args:           []safeTrieFunctionArgs{{path: "/path/to/functions/", functions: []string{"test-functions"}}},
-			expectedResult: map[string]FunctionTarget{"/path/to/functions/": SingleTarget("test-functions")},
+			args:           []safeTrieTestArgs{{path: "/path/to/targets/", targets: []string{"test-target"}}},
+			expectedResult: map[string]Target{"/path/to/targets/": SingleTarget("test-target")},
 		}, {
 			name:           "path with dots",
-			args:           []safeTrieFunctionArgs{{path: "/path/./to/./functions/", functions: []string{"test-functions"}}},
-			expectedResult: map[string]FunctionTarget{"/path/./to/./functions/": SingleTarget("test-functions")},
+			args:           []safeTrieTestArgs{{path: "/path/./to/./targets/", targets: []string{"test-target"}}},
+			expectedResult: map[string]Target{"/path/./to/./targets/": SingleTarget("test-target")},
 		}, {
 			name:           "upper case path",
-			args:           []safeTrieFunctionArgs{{path: "/PATH/TO/functions", functions: []string{"test-functions"}}},
-			expectedResult: map[string]FunctionTarget{"/PATH/TO/functions": SingleTarget("test-functions")},
+			args:           []safeTrieTestArgs{{path: "/PATH/TO/targets", targets: []string{"test-target"}}},
+			expectedResult: map[string]Target{"/PATH/TO/targets": SingleTarget("test-target")},
 		}, {
-			name: "upper case functions name",
-			args: []safeTrieFunctionArgs{
-				{path: "/path/to/functions", functions: []string{"test-functions"}},
-				{path: "/path/to/functions", functions: []string{"test-functions", "test-FUNCTION"}},
+			name: "upper case targets name",
+			args: []safeTrieTestArgs{
+				{path: "/path/to/targets", targets: []string{"test-target"}},
+				{path: "/path/to/targets", targets: []string{"test-target", "test-TARGET"}},
 			},
-			expectedResult: map[string]FunctionTarget{"/path/to/functions": &CanaryTarget{[2]string{"test-functions", "test-FUNCTION"}}},
+			expectedResult: map[string]Target{"/path/to/targets": PairTarget{"test-target", "test-TARGET"}},
 		}, {
 			name: "path with numbers and hyphens",
-			args: []safeTrieFunctionArgs{
-				{path: "/api/v1/user-data/123", functions: []string{"test-functions"}},
+			args: []safeTrieTestArgs{
+				{path: "/api/v1/user-data/123", targets: []string{"test-target"}},
 			},
-			expectedResult: map[string]FunctionTarget{"/api/v1/user-data/123": SingleTarget("test-functions")},
+			expectedResult: map[string]Target{"/api/v1/user-data/123": SingleTarget("test-target")},
 		},
 	} {
 		suite.Run(testCase.name, func() {
-			testSafeTrie := suite.generateSafeTrieForTest([]safeTrieFunctionArgs{})
+			testSafeTrie := suite.generateSafeTrieForTest([]safeTrieTestArgs{})
 			for _, setArgs := range testCase.args {
-				err := testSafeTrie.Set(setArgs.path, setArgs.functions)
+				err := testSafeTrie.Set(setArgs.path, setArgs.targets)
 				if testCase.expectError {
 					suite.Require().Error(err)
 					suite.Require().ErrorContains(err, testCase.errorMessage)
@@ -201,37 +201,37 @@ func (suite *SafeTrieTestSuite) TestPathTreeSet() {
 }
 func (suite *SafeTrieTestSuite) TestPathTreeGet() {
 	suite.T().Parallel()
-	initialStateGetTest := []safeTrieFunctionArgs{
-		{"/", []string{"test-functions"}},
-		{"/path/to/function1", []string{"test-function1"}},
-		{"/path/to/function1/nested", []string{"test-function2"}},
-		{"/path/./to/./functions/", []string{"test-function1"}},
-		{"path//to//functions/", []string{"test-function1"}},
-		{"/path/to/multiple/functions", []string{"test-function1", "test-function2"}},
+	initialStateGetTest := []safeTrieTestArgs{
+		{"/", []string{"test-target"}},
+		{"/path/to/target1", []string{"test-target1"}},
+		{"/path/to/target1/nested", []string{"test-target2"}},
+		{"/path/./to/./targets/", []string{"test-target1"}},
+		{"path//to//targets/", []string{"test-target1"}},
+		{"/path/to/multiple/targets", []string{"test-target1", "test-target2"}},
 	}
 	for _, testCase := range []struct {
 		name           string
 		path           string
-		expectedResult FunctionTarget
+		expectedResult Target
 		expectError    bool
 		errorMessage   string
 	}{
 		{
 			name:           "get root path",
 			path:           "/",
-			expectedResult: SingleTarget("test-functions"),
+			expectedResult: SingleTarget("test-target"),
 		}, {
 			name:           "get regular path",
-			path:           "/path/to/function1",
-			expectedResult: SingleTarget("test-function1"),
+			path:           "/path/to/target1",
+			expectedResult: SingleTarget("test-target1"),
 		}, {
 			name:           "get nested path",
-			path:           "/path/to/function1/nested",
-			expectedResult: SingleTarget("test-function2"),
+			path:           "/path/to/target1/nested",
+			expectedResult: SingleTarget("test-target2"),
 		}, {
 			name:           "get closest match",
-			path:           "/path/to/function1/nested/extra",
-			expectedResult: SingleTarget("test-function2"),
+			path:           "/path/to/target1/nested/extra",
+			expectedResult: SingleTarget("test-target2"),
 		}, {
 			name:         "get empty path",
 			path:         "",
@@ -239,20 +239,20 @@ func (suite *SafeTrieTestSuite) TestPathTreeGet() {
 			errorMessage: "path is empty",
 		}, {
 			name:           "get closest match with different suffix",
-			path:           "/path/to/function1/something/else",
-			expectedResult: SingleTarget("test-function1"),
+			path:           "/path/to/target1/something/else",
+			expectedResult: SingleTarget("test-target1"),
 		}, {
 			name:           "get path with dots",
-			path:           "/path/./to/./functions/",
-			expectedResult: SingleTarget("test-function1"),
+			path:           "/path/./to/./targets/",
+			expectedResult: SingleTarget("test-target1"),
 		}, {
 			name:           "get path with slash",
-			path:           "path//to//functions/",
-			expectedResult: SingleTarget("test-function1"),
+			path:           "path//to//targets/",
+			expectedResult: SingleTarget("test-target1"),
 		}, {
-			name:           "get multiple functions for the same path",
-			path:           "/path/to/multiple/functions",
-			expectedResult: &CanaryTarget{[2]string{"test-function1", "test-function2"}},
+			name:           "get multiple targets for the same path",
+			path:           "/path/to/multiple/targets",
+			expectedResult: PairTarget{"test-target1", "test-target2"},
 		},
 	} {
 		suite.Run(testCase.name, func() {
@@ -271,76 +271,76 @@ func (suite *SafeTrieTestSuite) TestPathTreeGet() {
 func (suite *SafeTrieTestSuite) TestPathTreeDelete() {
 	suite.T().Parallel()
 	for _, testCase := range []struct {
-		initialState   []safeTrieFunctionArgs // initial state of the path tree before delete
+		initialState   []safeTrieTestArgs // initial state of the path tree before delete
 		name           string
-		deleteArgs     safeTrieFunctionArgs
-		expectedResult map[string]FunctionTarget
+		deleteArgs     safeTrieTestArgs
+		expectedResult map[string]Target
 		expectError    bool
 		errorMessage   string
 	}{
 		{
 			name: "delete a path and validate that nested path is still there",
-			initialState: []safeTrieFunctionArgs{
-				{"/path/to/function1", []string{"test-function1"}},
-				{"/path/to/function1/nested", []string{"test-function2"}},
+			initialState: []safeTrieTestArgs{
+				{"/path/to/target1", []string{"test-target1"}},
+				{"/path/to/target1/nested", []string{"test-target2"}},
 			},
-			deleteArgs: safeTrieFunctionArgs{"/path/to/function1", []string{"test-function1"}},
-			expectedResult: map[string]FunctionTarget{
-				"/path/to/function1/nested": SingleTarget("test-function2"),
-			},
-		}, {
-			name: "delete a functions from multiple values shouldn't do anything, validate that the functions is still there",
-			initialState: []safeTrieFunctionArgs{
-				{"/path/to/multiple/functions", []string{"test-function1", "test-function2"}},
-			},
-			deleteArgs: safeTrieFunctionArgs{"/path/to/multiple/functions", []string{"test-function1"}},
-			expectedResult: map[string]FunctionTarget{
-				"/path/to/multiple/functions": &CanaryTarget{[2]string{"test-function1", "test-function2"}},
+			deleteArgs: safeTrieTestArgs{"/path/to/target1", []string{"test-target1"}},
+			expectedResult: map[string]Target{
+				"/path/to/target1/nested": SingleTarget("test-target2"),
 			},
 		}, {
-			name: "delete functions that does not exist in the path",
-			initialState: []safeTrieFunctionArgs{
-				{"/path/to/function1", []string{"test-function1"}},
+			name: "delete a targets from multiple values shouldn't do anything, validate that the targets is still there",
+			initialState: []safeTrieTestArgs{
+				{"/path/to/multiple/targets", []string{"test-target1", "test-target2"}},
 			},
-			deleteArgs: safeTrieFunctionArgs{"/path/to/function1", []string{"test-function2"}},
-			expectedResult: map[string]FunctionTarget{
-				"/path/to/function1": SingleTarget("test-function1"),
+			deleteArgs: safeTrieTestArgs{"/path/to/multiple/targets", []string{"test-target1"}},
+			expectedResult: map[string]Target{
+				"/path/to/multiple/targets": PairTarget{"test-target1", "test-target2"},
 			},
 		}, {
-			name: "delete functions that does not exist in multiple value path",
-			initialState: []safeTrieFunctionArgs{
-				{"/path/to/functions", []string{"test-function1", "test-function2"}},
+			name: "delete targets that does not exist in the path",
+			initialState: []safeTrieTestArgs{
+				{"/path/to/target1", []string{"test-target1"}},
 			},
-			deleteArgs: safeTrieFunctionArgs{"/path/to/functions", []string{"test-not-existing-functions"}},
-			expectedResult: map[string]FunctionTarget{
-				"/path/to/functions": &CanaryTarget{[2]string{"test-function1", "test-function2"}},
+			deleteArgs: safeTrieTestArgs{"/path/to/target1", []string{"test-target2"}},
+			expectedResult: map[string]Target{
+				"/path/to/target1": SingleTarget("test-target1"),
+			},
+		}, {
+			name: "delete targets that does not exist in multiple value path",
+			initialState: []safeTrieTestArgs{
+				{"/path/to/targets", []string{"test-target1", "test-target2"}},
+			},
+			deleteArgs: safeTrieTestArgs{"/path/to/targets", []string{"test-not-existing-targets"}},
+			expectedResult: map[string]Target{
+				"/path/to/targets": PairTarget{"test-target1", "test-target2"},
 			},
 		}, {
 			name: "delete not exist path",
-			initialState: []safeTrieFunctionArgs{
-				{"/path/to/function1", []string{"test-function1"}},
+			initialState: []safeTrieTestArgs{
+				{"/path/to/target1", []string{"test-target1"}},
 			},
-			deleteArgs: safeTrieFunctionArgs{"/path/to/function1/nested", []string{"test-function2"}},
-			expectedResult: map[string]FunctionTarget{
-				"/path/to/function1": SingleTarget("test-function1"),
+			deleteArgs: safeTrieTestArgs{"/path/to/target1/nested", []string{"test-target2"}},
+			expectedResult: map[string]Target{
+				"/path/to/target1": SingleTarget("test-target1"),
 			},
 		}, {
 			name: "delete path with suffix that does not exist",
-			initialState: []safeTrieFunctionArgs{
-				{"/path/to/function1", []string{"test-function1"}},
-				{"/path/to/function1/nested", []string{"test-function2"}},
+			initialState: []safeTrieTestArgs{
+				{"/path/to/target1", []string{"test-target1"}},
+				{"/path/to/target1/nested", []string{"test-target2"}},
 			},
-			deleteArgs: safeTrieFunctionArgs{"/path/to/function1/path/suffix", []string{"test-function1"}},
-			expectedResult: map[string]FunctionTarget{
-				"/path/to/function1":        SingleTarget("test-function1"),
-				"/path/to/function1/nested": SingleTarget("test-function2"),
+			deleteArgs: safeTrieTestArgs{"/path/to/target1/path/suffix", []string{"test-target1"}},
+			expectedResult: map[string]Target{
+				"/path/to/target1":        SingleTarget("test-target1"),
+				"/path/to/target1/nested": SingleTarget("test-target2"),
 			},
 		},
 	} {
 		suite.Run(testCase.name, func() {
 			testSafeTrie := suite.generateSafeTrieForTest(testCase.initialState)
 
-			err := testSafeTrie.Delete(testCase.deleteArgs.path, testCase.deleteArgs.functions)
+			err := testSafeTrie.Delete(testCase.deleteArgs.path, testCase.deleteArgs.targets)
 			if testCase.expectError {
 				suite.Require().Error(err)
 				suite.Require().ErrorContains(err, testCase.errorMessage)
@@ -348,7 +348,7 @@ func (suite *SafeTrieTestSuite) TestPathTreeDelete() {
 				suite.Require().NoError(err)
 			}
 
-			// After delete, check that the expected paths and functions are as expected
+			// After delete, check that the expected paths and targets are as expected
 			flattenSafeTrie, err := flattenSafeTrie(testSafeTrie)
 			suite.Require().NoError(err)
 			suite.Require().Equal(testCase.expectedResult, flattenSafeTrie)
@@ -358,7 +358,7 @@ func (suite *SafeTrieTestSuite) TestPathTreeDelete() {
 func (suite *SafeTrieTestSuite) TestPathTreeIsEmpty() {
 	suite.T().Parallel()
 	for _, testCase := range []struct {
-		initialState   []safeTrieFunctionArgs // initial state of the path tree before delete
+		initialState   []safeTrieTestArgs // initial state of the path tree before delete
 		name           string
 		expectedResult bool
 	}{
@@ -368,8 +368,8 @@ func (suite *SafeTrieTestSuite) TestPathTreeIsEmpty() {
 		}, {
 			name:           "is empty with not empty trie",
 			expectedResult: false,
-			initialState: []safeTrieFunctionArgs{
-				{"/test/path/", []string{"test-function1"}},
+			initialState: []safeTrieTestArgs{
+				{"/test/path/", []string{"test-target1"}},
 			},
 		},
 	} {
@@ -384,19 +384,19 @@ func (suite *SafeTrieTestSuite) TestPathTreeIsEmpty() {
 
 // --- SafeTrieTestSuite suite methods ---
 
-// flattenSafeTrie converts a PathTrie into a map[string]FunctionTarget
-// This functions is not part of the SafeTrieTestSuite because it is also in use in IngressCacheTestSuite
-func flattenSafeTrie(st *SafeTrie) (map[string]FunctionTarget, error) {
-	resultMap := make(map[string]FunctionTarget)
+// flattenSafeTrie converts a PathTrie into a map[string]Target
+// This targets is not part of the SafeTrieTestSuite because it is also in use in IngressCacheTestSuite
+func flattenSafeTrie(st *SafeTrie) (map[string]Target, error) {
+	resultMap := make(map[string]Target)
 	err := st.pathTrie.Walk(func(key string, value interface{}) error {
-		// The Walk functions iterates over all nodes.
+		// The Walk targets iterates over all nodes.
 		// Only store key-value pairs where a non-nil value has been explicitly 'Put'.
 		// If a node exists as an internal prefix (e.g., "/a" for "/a/b"), its 'value' will be nil.
 		// We only care about the values that were actually stored.
 		if value != nil {
-			convertedValue, ok := value.(FunctionTarget)
+			convertedValue, ok := value.(Target)
 			if !ok {
-				return fmt.Errorf("path value should be FunctionTarget")
+				return fmt.Errorf("path value should be Target")
 			}
 			resultMap[key] = convertedValue
 		}
@@ -408,40 +408,40 @@ func flattenSafeTrie(st *SafeTrie) (map[string]FunctionTarget, error) {
 	return resultMap, nil
 }
 
-func (suite *SafeTrieTestSuite) generatePathsAndFunctions(num int) []safeTrieFunctionArgs {
-	args := make([]safeTrieFunctionArgs, num)
+func (suite *SafeTrieTestSuite) generatePathsAndTargets(num int) []safeTrieTestArgs {
+	args := make([]safeTrieTestArgs, num)
 	for i := 0; i < num; i++ {
-		path := fmt.Sprintf("/path/to/functions/%d", i)
-		functions := []string{fmt.Sprintf("functions-%d", i)}
-		args[i] = safeTrieFunctionArgs{path: path, functions: functions}
+		path := fmt.Sprintf("/path/to/target/%d", i)
+		target := []string{fmt.Sprintf("target-%d", i)}
+		args[i] = safeTrieTestArgs{path: path, targets: target}
 	}
 	return args
 }
 
-func (suite *SafeTrieTestSuite) generateExpectedResultMap(num int) map[string]FunctionTarget {
-	expectedResult := make(map[string]FunctionTarget)
-	args := suite.generatePathsAndFunctions(num)
+func (suite *SafeTrieTestSuite) generateExpectedResultMap(num int) map[string]Target {
+	expectedResult := make(map[string]Target)
+	args := suite.generatePathsAndTargets(num)
 	for i := 0; i < num; i++ {
-		expectedResult[args[i].path] = SingleTarget(args[i].functions[0])
+		expectedResult[args[i].path] = SingleTarget(args[i].targets[0])
 	}
 	return expectedResult
 }
 
 // generateSafeTrieForTest creates a SafeTrie instance and sets the provided initial state
-func (suite *SafeTrieTestSuite) generateSafeTrieForTest(initialSafeTrieState []safeTrieFunctionArgs) *SafeTrie {
+func (suite *SafeTrieTestSuite) generateSafeTrieForTest(initialSafeTrieState []safeTrieTestArgs) *SafeTrie {
 	var err error
 	safeTrie := NewSafeTrie()
 
 	// set path tree with the provided required state
 	for _, args := range initialSafeTrieState {
-		err = safeTrie.Set(args.path, args.functions)
+		err = safeTrie.Set(args.path, args.targets)
 		suite.Require().NoError(err)
 	}
 
 	return safeTrie
 }
 
-func TestSafeTrie(t *testing.T) {
+func TestSafeTrieSuite(t *testing.T) {
 	suite.Run(t, new(SafeTrieTestSuite))
 }
 
@@ -453,32 +453,32 @@ type SingleTargetTestSuite struct {
 func (suite *SingleTargetTestSuite) TestEqual() {
 	testCases := []struct {
 		name           string
-		functionTarget FunctionTarget
+		target         Target
 		expectedResult bool
 	}{
 		{
 			name:           "Equal exact match",
-			functionTarget: SingleTarget("myFunction"),
+			target:         SingleTarget("test-target1"),
 			expectedResult: true,
 		}, {
 			name:           "Equal no match",
-			functionTarget: SingleTarget("otherFunction"),
+			target:         SingleTarget("test-target2"),
 			expectedResult: false,
 		}, {
-			name:           "Equal empty functions name no match",
-			functionTarget: SingleTarget(""),
+			name:           "Equal empty target name no match",
+			target:         SingleTarget(""),
 			expectedResult: false,
 		}, {
 			name:           "Equal canary no match",
-			functionTarget: CanaryTarget{functionNames: [2]string{}},
+			target:         PairTarget{"test-target1", "test-target2"},
 			expectedResult: false,
 		},
 	}
 
 	for _, testCase := range testCases {
 		suite.Run(testCase.name, func() {
-			testSingleFunctionName := SingleTarget("myFunction")
-			result := testSingleFunctionName.Equal(testCase.functionTarget)
+			testSingleTarget := SingleTarget("test-target1")
+			result := testSingleTarget.Equal(testCase.target)
 			suite.Equal(testCase.expectedResult, result)
 		})
 	}
@@ -486,106 +486,106 @@ func (suite *SingleTargetTestSuite) TestEqual() {
 
 func (suite *SingleTargetTestSuite) TestToSliceString() {
 	testCases := []struct {
-		name               string
-		singleFunctionName string
-		expectedResult     []string
+		name             string
+		singleTargetName string
+		expectedResult   []string
 	}{
 		{
-			name:               "ToSliceStringWithFunction",
-			singleFunctionName: "toSliceStringFunction",
-			expectedResult:     []string{"toSliceStringFunction"},
+			name:             "ToSliceStringWithTarget",
+			singleTargetName: "toSliceStringTarget",
+			expectedResult:   []string{"toSliceStringTarget"},
 		}, {
-			name:               "ToSliceStringWithSpecialChars",
-			singleFunctionName: "my-function_123",
-			expectedResult:     []string{"my-function_123"},
+			name:             "ToSliceStringWithSpecialChars",
+			singleTargetName: "my-target_123",
+			expectedResult:   []string{"my-target_123"},
 		},
 	}
 
 	for _, testCase := range testCases {
 		suite.Run(testCase.name, func() {
-			testSingleFunctionName := SingleTarget(testCase.singleFunctionName)
-			result := testSingleFunctionName.ToSliceString()
+			testSingleTarget := SingleTarget(testCase.singleTargetName)
+			result := testSingleTarget.ToSliceString()
 			suite.Equal(testCase.expectedResult, result)
 			suite.Len(result, 1)
 		})
 	}
 }
 
-// TestSingleFunctionNameTestSuite runs the test suite
-func TestSingleFunctionNameTestSuite(t *testing.T) {
+// TestSingleTargetTestSuite runs the test suite
+func TestSingleTargetTestSuite(t *testing.T) {
 	suite.Run(t, new(SingleTargetTestSuite))
 }
 
-// --- CanaryTargetTestSuite ---
-type CanaryTargetTestSuite struct {
+// --- PairTargetTestSuite ---
+type PairTargetTestSuite struct {
 	suite.Suite
 }
 
-func (suite *CanaryTargetTestSuite) TestEqual() {
+func (suite *PairTargetTestSuite) TestEqual() {
 	testCases := []struct {
 		name           string
-		functionTarget FunctionTarget
+		target         Target
 		expectedResult bool
 	}{
 		{
 			name:           "Equal match",
-			functionTarget: &CanaryTarget{[2]string{"test-function1", "test-function2"}},
+			target:         PairTarget{"test-target1", "test-target2"},
 			expectedResult: true,
 		}, {
 			name:           "Equal no match",
-			functionTarget: &CanaryTarget{[2]string{"test-function1", "test-function3"}},
+			target:         PairTarget{"test-target1", "test-target3"},
 			expectedResult: false,
 		}, {
-			name:           "Equal empty functions name",
-			functionTarget: &CanaryTarget{[2]string{}},
+			name:           "Equal empty targets name",
+			target:         PairTarget{},
 			expectedResult: false,
 		}, {
 			name:           "Equal case sensitive",
-			functionTarget: &CanaryTarget{[2]string{"TEST-function1", "test-function2"}},
+			target:         PairTarget{"TEST-target1", "test-target2"},
 			expectedResult: false,
 		}, {
-			name:           "Equal with single functions",
-			functionTarget: SingleTarget("test-function1"),
+			name:           "Equal with single targets",
+			target:         SingleTarget("test-target1"),
 			expectedResult: false,
 		},
 	}
 
 	for _, testCase := range testCases {
 		suite.Run(testCase.name, func() {
-			testCanaryFunctionNames := &CanaryTarget{[2]string{"test-function1", "test-function2"}}
-			result := testCanaryFunctionNames.Equal(testCase.functionTarget)
+			testTargets := PairTarget{"test-target1", "test-target2"}
+			result := testTargets.Equal(testCase.target)
 			suite.Equal(testCase.expectedResult, result)
 		})
 	}
 }
 
-func (suite *CanaryTargetTestSuite) TestToSliceString() {
+func (suite *PairTargetTestSuite) TestToSliceString() {
 	testCases := []struct {
 		name           string
-		canaryTarget   [2]string
+		target         [2]string
 		expectedResult []string
 	}{
 		{
-			name:           "ToSliceStringWithFunction",
-			canaryTarget:   [2]string{"test-function1", "test-function2"},
-			expectedResult: []string{"test-function1", "test-function2"},
+			name:           "ToSliceStringWithTargets",
+			target:         [2]string{"test-target1", "test-target2"},
+			expectedResult: []string{"test-target1", "test-target2"},
 		}, {
 			name:           "ToSliceStringWithSpecialChars",
-			canaryTarget:   [2]string{"my-function_123", "test-function2"},
-			expectedResult: []string{"my-function_123", "test-function2"},
+			target:         [2]string{"my-target_123", "test-target2"},
+			expectedResult: []string{"my-target_123", "test-target2"},
 		},
 	}
 
 	for _, testCase := range testCases {
 		suite.Run(testCase.name, func() {
-			testCanaryFunctionNames := &CanaryTarget{testCase.canaryTarget}
-			result := testCanaryFunctionNames.ToSliceString()
+			testTargets := PairTarget{testCase.target[0], testCase.target[1]}
+			result := testTargets.ToSliceString()
 			suite.Equal(testCase.expectedResult, result)
 		})
 	}
 }
 
-// TestCanaryFunctionNamesTestSuite runs the test suite
-func TestCanaryFunctionNamesTestSuite(t *testing.T) {
-	suite.Run(t, new(CanaryTargetTestSuite))
+// TestTargetsTestSuite runs the test suite
+func TestTargetsTestSuite(t *testing.T) {
+	suite.Run(t, new(PairTargetTestSuite))
 }

--- a/pkg/ingresscache/types.go
+++ b/pkg/ingresscache/types.go
@@ -21,7 +21,7 @@ such restriction.
 package ingresscache
 
 type IngressHostCache interface {
-	// Set adds a new item to the cache for the given host, path and targets name. Will overwrite existing values if any
+	// Set adds a new item to the cache for the given host, path and targets. Will overwrite existing values if any
 	Set(host string, path string, targets []string) error
 
 	// Delete removes the specified targets from the cache for the given host and path. Will do nothing if host, path or targets do not exist
@@ -32,13 +32,13 @@ type IngressHostCache interface {
 }
 
 type IngressHostsTree interface {
-	// Set sets a targets for a given path. Will overwrite existing values if the path already exists
+	// Set sets the targets for a given path. Will overwrite existing values if the path already exists
 	Set(path string, targets []string) error
 
-	// Delete removes the targets from the given path and deletes the deepest suffix used only by that targets; does nothing if the path or targets doesn't exist.
+	// Delete removes the targets from the given path and deletes the deepest suffix used only by these targets; does nothing if the path or targets don't exist.
 	Delete(path string, targets []string) error
 
-	// Get retrieves the best matching target names for a given path based on longest prefix match
+	// Get retrieves the best matching targets for a given path based on longest prefix match
 	Get(path string) (Target, error)
 
 	// IsEmpty checks if the tree is empty
@@ -50,6 +50,6 @@ type Target interface {
 	// Equal returns true if the otherTarget is equal to the current target
 	Equal(otherTarget Target) bool
 
-	// ToSliceString returns a slice of targets names
+	// ToSliceString returns a slice of targets
 	ToSliceString() []string
 }

--- a/pkg/ingresscache/types.go
+++ b/pkg/ingresscache/types.go
@@ -21,35 +21,35 @@ such restriction.
 package ingresscache
 
 type IngressHostCache interface {
-	// Set adds a new item to the cache for the given host, path and functions name. Will overwrite existing values if any
-	Set(host string, path string, function []string) error
+	// Set adds a new item to the cache for the given host, path and targets name. Will overwrite existing values if any
+	Set(host string, path string, targets []string) error
 
-	// Delete removes the specified functions from the cache for the given host and path. Will do nothing if host, path or functions do not exist
-	Delete(host string, path string, function []string) error
+	// Delete removes the specified targets from the cache for the given host and path. Will do nothing if host, path or targets do not exist
+	Delete(host string, path string, targets []string) error
 
-	// Get retrieves all function names for the given host and path
+	// Get retrieves all target names for the given host and path
 	Get(host string, path string) ([]string, error)
 }
 
 type IngressHostsTree interface {
-	// Set sets a functions for a given path. Will overwrite existing values if the path already exists
-	Set(path string, functions []string) error
+	// Set sets a targets for a given path. Will overwrite existing values if the path already exists
+	Set(path string, targets []string) error
 
-	// Delete removes the functions from the given path and deletes the deepest suffix used only by that functions; does nothing if the path or functions doesn't exist.
-	Delete(path string, functions []string) error
+	// Delete removes the targets from the given path and deletes the deepest suffix used only by that targets; does nothing if the path or targets doesn't exist.
+	Delete(path string, targets []string) error
 
-	// Get retrieves the best matching function names for a given path based on longest prefix match
-	Get(path string) (FunctionTarget, error)
+	// Get retrieves the best matching target names for a given path based on longest prefix match
+	Get(path string) (Target, error)
 
 	// IsEmpty checks if the tree is empty
 	IsEmpty() bool
 }
 
-// FunctionTarget defines the trie.PathTrie value
-type FunctionTarget interface {
-	// Equal checks if the functions functionTarget is the same as the provided FunctionTarget
-	Equal(functionTarget FunctionTarget) bool
+// Target defines the trie.PathTrie value
+type Target interface {
+	// Equal returns true if the otherTarget is equal to the current target
+	Equal(otherTarget Target) bool
 
-	// ToSliceString returns a slice of functions names
+	// ToSliceString returns a slice of targets names
 	ToSliceString() []string
 }

--- a/pkg/ingresscache/types.go
+++ b/pkg/ingresscache/types.go
@@ -21,22 +21,22 @@ such restriction.
 package ingresscache
 
 type IngressHostCache interface {
-	// Set adds a new item to the cache for the given host, path and function name. Will overwrite existing values if any
-	Set(host string, path string, function string) error
+	// Set adds a new item to the cache for the given host, path and functions name. Will overwrite existing values if any
+	Set(host string, path string, function []string) error
 
-	// Delete removes the specified function from the cache for the given host and path. Will do nothing if host, path or function do not exist
-	Delete(host string, path string, function string) error
+	// Delete removes the specified functions from the cache for the given host and path. Will do nothing if host, path or functions do not exist
+	Delete(host string, path string, function []string) error
 
 	// Get retrieves all function names for the given host and path
 	Get(host string, path string) ([]string, error)
 }
 
 type IngressHostsTree interface {
-	// Set sets a function for a given path. Will overwrite existing values if the path already exists
-	Set(path string, function string) error
+	// Set sets a functions for a given path. Will overwrite existing values if the path already exists
+	Set(path string, functions []string) error
 
-	// Delete removes the function from the given path and deletes the deepest suffix used only by that function; does nothing if the path or function doesn't exist.
-	Delete(path string, function string) error
+	// Delete removes the functions from the given path and deletes the deepest suffix used only by that functions; does nothing if the path or functions doesn't exist.
+	Delete(path string, functions []string) error
 
 	// Get retrieves the best matching function names for a given path based on longest prefix match
 	Get(path string) (FunctionTarget, error)
@@ -47,18 +47,9 @@ type IngressHostsTree interface {
 
 // FunctionTarget defines the trie.PathTrie value
 type FunctionTarget interface {
-	// Contains checks if the function name is present
-	Contains(functionName string) bool
+	// Equal checks if the functions functionTarget is the same as the provided FunctionTarget
+	Equal(functionTarget FunctionTarget) bool
 
-	// Delete returns an updated FunctionTarget after removing the function name
-	Delete(functionName string) (FunctionTarget, error)
-
-	// Add returns an updated FunctionTarget after adding the function name
-	Add(functionName string) (FunctionTarget, error)
-
-	// ToSliceString returns a slice of function names
+	// ToSliceString returns a slice of functions names
 	ToSliceString() []string
-
-	// IsSingle returns true if the struct type is SingleTarget
-	IsSingle() bool
 }


### PR DESCRIPTION
### **Motivation**  
Enable the watching operator to use the cache through its interface without needing awareness of the underlying implementation.

### **Root Cause**  
The original interfaces were designed to support a single string, which turned out to be insufficient. 
This refactoring updates them to use `[]string` instead. 
Using string slices allows for a simpler and more accurate implementation of the cache, better aligned with the behavior defined in the HLD.

### **Description**  
For more details, see Jira: https://iguazio.atlassian.net/browse/NUC-502

### **Affected Areas**  
This PR is a prerequisite for NUC-498

### **Testing**  
- Updated all unit tests and flow tests to reflect and validate the new behavior

### **Changes Made**  
- Updated `IngressHostCache` to use `[]string` instead of `string` for all relevant methods (Set, Delete) to reflect support for multiple functions.
- Updated `IngressHostsTree` to also operate on `[]string` rather than `string` for consistency and alignment with the cache layer.
- Refactored `FunctionTarget` to simplify its role: only `Equal()` and `ToSliceString()` remain, as other behaviors (Add, Delete, Contains, IsSingle) were removed in favor of simplified usage patterns.
