### PR TITLE
[Framework] implement ingress operator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,12 @@ module github.com/v3io/scaler
 go 1.23.8
 
 require (
+	github.com/dghubble/trie v0.1.0
 	github.com/nuclio/errors v0.0.4
 	github.com/nuclio/logger v0.0.1
 	github.com/nuclio/zap v0.3.1
 	github.com/stretchr/testify v1.10.0
+	k8s.io/api v0.29.8
 	k8s.io/apimachinery v0.29.8
 	k8s.io/client-go v0.29.8
 	k8s.io/metrics v0.29.8
@@ -15,6 +17,7 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.12.2 // indirect
+	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-openapi/jsonpointer v0.21.1 // indirect
 	github.com/go-openapi/jsonreference v0.21.0 // indirect
@@ -22,9 +25,10 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/gnostic-models v0.6.9 // indirect
+	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/imdario/mergo v0.3.7 // indirect
+	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/logrusorgru/aurora/v4 v4.0.0 // indirect
@@ -32,10 +36,10 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	github.com/dghubble/trie v0.1.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/net v0.41.0 // indirect
@@ -47,7 +51,6 @@ require (
 	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.29.8 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect
 	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,10 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/emicklei/go-restful/v3 v3.12.2 h1:DhwDP0vY3k8ZzE0RunuJy8GhNpPL6zqLkDf9B/a0/xU=
-github.com/emicklei/go-restful/v3 v3.12.2/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/dghubble/trie v0.1.0 h1:kJnjBLFFElBwS60N4tkPvnLhnpcDxbBjIulgI8CpNGM=
 github.com/dghubble/trie v0.1.0/go.mod h1:sOmnzfBNH7H92ow2292dDFWNsVQuh/izuD7otCYb1ak=
+github.com/emicklei/go-restful/v3 v3.12.2 h1:DhwDP0vY3k8ZzE0RunuJy8GhNpPL6zqLkDf9B/a0/xU=
+github.com/emicklei/go-restful/v3 v3.12.2/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH5pOlLGNtQ5lPWQu84=
 github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
@@ -34,8 +34,8 @@ github.com/google/pprof v0.0.0-20240727154555-813a5fbdbec8 h1:FKHo8hFI3A+7w0aUQu
 github.com/google/pprof v0.0.0-20240727154555-813a5fbdbec8/go.mod h1:K1liHPHnj73Fdn/EKuT8nrFqBihUSKXoLYU0BuatOYo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/imdario/mergo v0.3.7 h1:Y+UAYTZ7gDEuOfhxKWy+dvb5dRQ6rJjFSdX2HZY1/gI=
-github.com/imdario/mergo v0.3.7/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/imdario/mergo v0.3.13 h1:lFzP57bqS/wsqKssCGmtLAb8A0wKjLGrve2q3PPVcBk=
+github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK2O4oXg=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
@@ -135,8 +135,7 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
-gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
+gopkg.in/yaml.v3 v3.0.0/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 k8s.io/api v0.29.8 h1:ZBKg9clWnIGtQ5yGhNwMw2zyyrsIAQaXhZACcYNflQE=

--- a/pkg/kube/ingress.go
+++ b/pkg/kube/ingress.go
@@ -31,12 +31,13 @@ func NewIngressWatcher(
 	ctx context.Context,
 	dlxLogger logger.Logger,
 	kubeClient kubernetes.Interface,
+	ingressCache *ingresscache.IngressCache,
 	resolveCallback ResolveTargetsFromIngressCallback,
 	namespace, labelsFilter string,
 ) (*IngressWatcher, error) {
 	factory := informers.NewSharedInformerFactoryWithOptions(
 		kubeClient,
-		30*time.Second, //TODO - consider make if configurable or const
+		30*time.Second,
 		informers.WithNamespace(namespace),
 		informers.WithTweakListOptions(func(options *metav1.ListOptions) {
 			options.LabelSelector = labelsFilter
@@ -47,7 +48,7 @@ func NewIngressWatcher(
 	ingressWatcher := &IngressWatcher{
 		ctx:                    ctx,
 		logger:                 dlxLogger,
-		ingressCache:           ingresscache.NewIngressCache(dlxLogger), //TODO - consider decouple the ingress cache init from the watcher
+		ingressCache:           ingressCache,
 		factory:                factory,
 		informer:               ingressInformer,
 		resolveTargetsCallback: resolveCallback,

--- a/pkg/kube/ingress.go
+++ b/pkg/kube/ingress.go
@@ -141,7 +141,7 @@ func (iw *IngressWatcher) Stop() {
 func (iw *IngressWatcher) AddHandler(obj interface{}) {
 	ingress, err := iw.extractValuesFromIngressResource(obj)
 	if err != nil {
-		iw.logger.WarnWith("Add ingress handler failure - failed to extract values from ingress resource",
+		iw.logger.DebugWith("Add ingress handler failure - failed to extract values from ingress resource",
 			"error", err.Error())
 		return
 	}
@@ -160,14 +160,14 @@ func (iw *IngressWatcher) AddHandler(obj interface{}) {
 func (iw *IngressWatcher) UpdateHandler(oldObj, newObj interface{}) {
 	oldIngress, err := iw.extractValuesFromIngressResource(oldObj)
 	if err != nil {
-		iw.logger.WarnWith("Update ingress handler - failed to extract values from old object",
+		iw.logger.DebugWith("Update ingress handler - failed to extract values from old object",
 			"error", err.Error())
 		return
 	}
 
 	newIngress, err := iw.extractValuesFromIngressResource(newObj)
 	if err != nil {
-		iw.logger.WarnWith("Update ingress handler - failed to extract values from new object",
+		iw.logger.DebugWith("Update ingress handler - failed to extract values from new object",
 			"error", err.Error())
 		return
 	}
@@ -198,7 +198,7 @@ func (iw *IngressWatcher) UpdateHandler(oldObj, newObj interface{}) {
 func (iw *IngressWatcher) DeleteHandler(obj interface{}) {
 	ingress, err := iw.extractValuesFromIngressResource(obj)
 	if err != nil {
-		iw.logger.WarnWith("Delete ingress handler failure- failed to extract values from object",
+		iw.logger.DebugWith("Delete ingress handler failure- failed to extract values from object",
 			"error", err.Error())
 		return
 	}

--- a/pkg/kube/ingress.go
+++ b/pkg/kube/ingress.go
@@ -4,15 +4,15 @@ import (
 	"context"
 	"time"
 
+	"github.com/v3io/scaler/pkg/ingresscache"
+
+	"github.com/nuclio/errors"
+	"github.com/nuclio/logger"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-
-	"github.com/nuclio/errors"
-	"github.com/nuclio/logger"
-	"github.com/v3io/scaler/pkg/ingresscache"
 )
 
 type ResolveTargetsFromIngressCallback func(ingress *networkingv1.Ingress) ([]string, error)

--- a/pkg/kube/ingress.go
+++ b/pkg/kube/ingress.go
@@ -59,6 +59,7 @@ const (
 type ResolveTargetsFromIngressCallback func(ingress *networkingv1.Ingress) ([]string, error)
 
 type ingressValue struct {
+	name    string
 	host    string
 	path    string
 	targets []string
@@ -151,11 +152,18 @@ func (iw *IngressWatcher) AddHandler(obj interface{}) {
 		iw.logger.WarnWith("Add ingress handler failure - failed to add the new value to ingress cache",
 			"error", err.Error(),
 			"object", obj,
+			"ingress name", ingress.name,
 			"host", ingress.host,
 			"path", ingress.path,
 			"targets", ingress.targets)
 		return
 	}
+
+	iw.logger.DebugWith("Add ingress handler - successfully added ingress to cache",
+		"ingress name", ingress.name,
+		"host", ingress.host,
+		"path", ingress.path,
+		"targets", ingress.targets)
 }
 
 func (iw *IngressWatcher) UpdateHandler(oldObj, newObj interface{}) {
@@ -178,6 +186,7 @@ func (iw *IngressWatcher) UpdateHandler(oldObj, newObj interface{}) {
 		if err := iw.cache.Delete(oldIngress.host, oldIngress.path, oldIngress.targets); err != nil {
 			iw.logger.WarnWith("Update ingress handler failure - failed to delete old ingress",
 				"error", err.Error(),
+				"ingress name", oldIngress.name,
 				"object", oldObj,
 				"host", oldIngress.host,
 				"path", oldIngress.path,
@@ -189,11 +198,18 @@ func (iw *IngressWatcher) UpdateHandler(oldObj, newObj interface{}) {
 		iw.logger.WarnWith("Update ingress handler failure - failed to add the new value",
 			"error", err.Error(),
 			"object", newObj,
+			"ingress name", newIngress.name,
 			"host", newIngress.host,
 			"path", newIngress.path,
 			"targets", newIngress.targets)
 		return
 	}
+
+	iw.logger.DebugWith("Update ingress handler - successfully updated ingress in cache",
+		"ingress name", newIngress.name,
+		"host", newIngress.host,
+		"path", newIngress.path,
+		"targets", newIngress.targets)
 }
 
 func (iw *IngressWatcher) DeleteHandler(obj interface{}) {
@@ -208,11 +224,18 @@ func (iw *IngressWatcher) DeleteHandler(obj interface{}) {
 		iw.logger.WarnWith("Delete ingress handler failure- failed delete from cache",
 			"error", err.Error(),
 			"object", obj,
+			"ingress name", ingress.name,
 			"host", ingress.host,
 			"path", ingress.path,
 			"targets", ingress.targets)
 		return
 	}
+
+	iw.logger.DebugWith("Delete ingress handler - successfully deleted ingress from cache",
+		"ingress name", ingress.name,
+		"host", ingress.host,
+		"path", ingress.path,
+		"targets", ingress.targets)
 }
 
 // --- internal methods ---
@@ -247,6 +270,7 @@ func (iw *IngressWatcher) extractValuesFromIngressResource(obj interface{}) (*in
 		host:    host,
 		path:    path,
 		targets: targets,
+		name:    ingress.Name,
 	}, nil
 }
 

--- a/pkg/kube/ingress.go
+++ b/pkg/kube/ingress.go
@@ -1,0 +1,92 @@
+package kube
+
+import (
+	"context"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"time"
+
+	"github.com/nuclio/errors"
+	"github.com/nuclio/logger"
+	"github.com/v3io/scaler/pkg/ingresscache"
+)
+
+// IngressWatcher watches for changes in Kubernetes Ingress resources and updates the ingress cache accordingly
+type IngressWatcher struct {
+	ctx          context.Context
+	logger       logger.Logger
+	ingressCache ingresscache.IngressHostCache
+	factory      informers.SharedInformerFactory
+	informer     cache.SharedIndexInformer
+}
+
+func NewIngressWatcher(
+	ctx context.Context,
+	dlxLogger logger.Logger,
+	kubeClient kubernetes.Interface,
+	namespace, labelsFilter string,
+) (*IngressWatcher, error) {
+	factory := informers.NewSharedInformerFactoryWithOptions(
+		kubeClient,
+		30*time.Second, //TODO - consider make if configurable or const
+		informers.WithNamespace(namespace),
+		informers.WithTweakListOptions(func(options *metav1.ListOptions) {
+			options.LabelSelector = labelsFilter
+		}),
+	)
+	ingressInformer := factory.Networking().V1().Ingresses().Informer()
+
+	ingressWatcher := &IngressWatcher{
+		ctx:          ctx,
+		logger:       dlxLogger,
+		ingressCache: ingresscache.NewIngressCache(dlxLogger), //TODO - consider decouple the ingress cache init from the watcher
+		factory:      factory,
+		informer:     ingressInformer,
+	}
+
+	//TODO - need to add event handler here -> ingressInformer.AddEventHandler
+
+	return ingressWatcher, nil
+}
+
+func (iw *IngressWatcher) Start() error {
+	iw.logger.Debug("Starting IngressWatcher")
+	iw.factory.Start(iw.ctx.Done())
+
+	if !cache.WaitForCacheSync(iw.ctx.Done(), iw.informer.HasSynced) {
+		return errors.New("failed to sync ingress cache")
+	}
+
+	return nil
+}
+
+func (iw *IngressWatcher) Stop() {
+	iw.logger.Debug("Stopping IngressWatcher")
+	iw.factory.Shutdown()
+}
+
+// --- internal methods ---
+
+// extractIngressValuesFromIngressResource extracts the host, path, and function name from the ingress resource.
+func (iw *IngressWatcher) extractIngressValuesFromIngressResource(obj interface{}) (string, string, string, error) {
+	ingress, ok := obj.(*networkingv1.Ingress)
+	if !ok {
+		return "", "", "", errors.New("Failed to cast object to Ingress")
+	}
+
+	//todo - add function to extract host, path and function name from ingress resource
+	// For now, we just store WA
+	host, path, function, err := iw.extractHostPathFunction(ingress)
+	if err != nil {
+		return "", "", "", errors.Wrap(err, "Failed to extract host, path and function from ingress")
+	}
+
+	return host, path, function, nil
+}
+
+func (iw *IngressWatcher) extractHostPathFunction(ingress *networkingv1.Ingress) (string, string, string, error) {
+	return "", "", "", nil //todo - implement this function to extract host, path and function name from ingress resource
+}

--- a/pkg/kube/ingress.go
+++ b/pkg/kube/ingress.go
@@ -1,3 +1,23 @@
+/*
+Copyright 2025 Iguazio Systems Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License") with
+an addition restriction as set forth herein. You may not use this
+file except in compliance with the License. You may obtain a copy of
+the License at http://www.apache.org/licenses/LICENSE-2.0.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing
+permissions and limitations under the License.
+
+In addition, you may not use the software for any purposes that are
+illegal under applicable law, and the grant of the foregoing license
+under the Apache 2.0 license is conditioned upon your compliance with
+such restriction.
+*/
+
 package kube
 
 import (

--- a/pkg/kube/ingress.go
+++ b/pkg/kube/ingress.go
@@ -83,7 +83,7 @@ func NewIngressWatcher(
 	resolveTargetsCallback ResolveTargetsFromIngressCallback,
 	resyncTimeout *time.Duration,
 	namespace string,
-	labelsFilter string,
+	labelSelector string,
 ) (*IngressWatcher, error) {
 	if resyncTimeout == nil {
 		defaultTimeout := defaultResyncInterval
@@ -95,7 +95,7 @@ func NewIngressWatcher(
 		*resyncTimeout,
 		informers.WithNamespace(namespace),
 		informers.WithTweakListOptions(func(options *metav1.ListOptions) {
-			options.LabelSelector = labelsFilter
+			options.LabelSelector = labelSelector
 		}),
 	)
 	ingressInformer := factory.Networking().V1().Ingresses().Informer()
@@ -152,7 +152,7 @@ func (iw *IngressWatcher) AddHandler(obj interface{}) {
 		iw.logger.WarnWith("Add ingress handler failure - failed to add the new value to ingress cache",
 			"error", err.Error(),
 			"object", obj,
-			"ingress name", ingress.name,
+			"ingressName", ingress.name,
 			"host", ingress.host,
 			"path", ingress.path,
 			"targets", ingress.targets)
@@ -160,7 +160,7 @@ func (iw *IngressWatcher) AddHandler(obj interface{}) {
 	}
 
 	iw.logger.DebugWith("Add ingress handler - successfully added ingress to cache",
-		"ingress name", ingress.name,
+		"ingressName", ingress.name,
 		"host", ingress.host,
 		"path", ingress.path,
 		"targets", ingress.targets)
@@ -186,7 +186,7 @@ func (iw *IngressWatcher) UpdateHandler(oldObj, newObj interface{}) {
 		if err := iw.cache.Delete(oldIngress.host, oldIngress.path, oldIngress.targets); err != nil {
 			iw.logger.WarnWith("Update ingress handler failure - failed to delete old ingress",
 				"error", err.Error(),
-				"ingress name", oldIngress.name,
+				"ingressName", oldIngress.name,
 				"object", oldObj,
 				"host", oldIngress.host,
 				"path", oldIngress.path,
@@ -198,7 +198,7 @@ func (iw *IngressWatcher) UpdateHandler(oldObj, newObj interface{}) {
 		iw.logger.WarnWith("Update ingress handler failure - failed to add the new value",
 			"error", err.Error(),
 			"object", newObj,
-			"ingress name", newIngress.name,
+			"ingressName", newIngress.name,
 			"host", newIngress.host,
 			"path", newIngress.path,
 			"targets", newIngress.targets)
@@ -206,7 +206,7 @@ func (iw *IngressWatcher) UpdateHandler(oldObj, newObj interface{}) {
 	}
 
 	iw.logger.DebugWith("Update ingress handler - successfully updated ingress in cache",
-		"ingress name", newIngress.name,
+		"ingressName", newIngress.name,
 		"host", newIngress.host,
 		"path", newIngress.path,
 		"targets", newIngress.targets)
@@ -215,16 +215,16 @@ func (iw *IngressWatcher) UpdateHandler(oldObj, newObj interface{}) {
 func (iw *IngressWatcher) DeleteHandler(obj interface{}) {
 	ingress, err := iw.extractValuesFromIngressResource(obj)
 	if err != nil {
-		iw.logger.DebugWith("Delete ingress handler failure- failed to extract values from object",
+		iw.logger.DebugWith("Delete ingress handler failure - failed to extract values from object",
 			"error", err.Error())
 		return
 	}
 
 	if err := iw.cache.Delete(ingress.host, ingress.path, ingress.targets); err != nil {
-		iw.logger.WarnWith("Delete ingress handler failure- failed delete from cache",
+		iw.logger.WarnWith("Delete ingress handler failure - failed delete from cache",
 			"error", err.Error(),
 			"object", obj,
-			"ingress name", ingress.name,
+			"ingressName", ingress.name,
 			"host", ingress.host,
 			"path", ingress.path,
 			"targets", ingress.targets)
@@ -232,7 +232,7 @@ func (iw *IngressWatcher) DeleteHandler(obj interface{}) {
 	}
 
 	iw.logger.DebugWith("Delete ingress handler - successfully deleted ingress from cache",
-		"ingress name", ingress.name,
+		"ingressName", ingress.name,
 		"host", ingress.host,
 		"path", ingress.path,
 		"targets", ingress.targets)

--- a/pkg/kube/ingress.go
+++ b/pkg/kube/ingress.go
@@ -2,31 +2,36 @@ package kube
 
 import (
 	"context"
+	"time"
+
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	"time"
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
 	"github.com/v3io/scaler/pkg/ingresscache"
 )
 
+type ResolveTargetsFromIngressCallback func(ingress *networkingv1.Ingress) ([]string, error)
+
 // IngressWatcher watches for changes in Kubernetes Ingress resources and updates the ingress cache accordingly
 type IngressWatcher struct {
-	ctx          context.Context
-	logger       logger.Logger
-	ingressCache ingresscache.IngressHostCache
-	factory      informers.SharedInformerFactory
-	informer     cache.SharedIndexInformer
+	ctx                    context.Context
+	logger                 logger.Logger
+	ingressCache           ingresscache.IngressHostCache
+	factory                informers.SharedInformerFactory
+	informer               cache.SharedIndexInformer
+	resolveTargetsCallback ResolveTargetsFromIngressCallback
 }
 
 func NewIngressWatcher(
 	ctx context.Context,
 	dlxLogger logger.Logger,
 	kubeClient kubernetes.Interface,
+	resolveCallback ResolveTargetsFromIngressCallback,
 	namespace, labelsFilter string,
 ) (*IngressWatcher, error) {
 	factory := informers.NewSharedInformerFactoryWithOptions(
@@ -40,11 +45,12 @@ func NewIngressWatcher(
 	ingressInformer := factory.Networking().V1().Ingresses().Informer()
 
 	ingressWatcher := &IngressWatcher{
-		ctx:          ctx,
-		logger:       dlxLogger,
-		ingressCache: ingresscache.NewIngressCache(dlxLogger), //TODO - consider decouple the ingress cache init from the watcher
-		factory:      factory,
-		informer:     ingressInformer,
+		ctx:                    ctx,
+		logger:                 dlxLogger,
+		ingressCache:           ingresscache.NewIngressCache(dlxLogger), //TODO - consider decouple the ingress cache init from the watcher
+		factory:                factory,
+		informer:               ingressInformer,
+		resolveTargetsCallback: resolveCallback,
 	}
 
 	if _, err := ingressInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -77,53 +83,52 @@ func (iw *IngressWatcher) Stop() {
 // --- ResourceEventHandler methods ---
 
 func (iw *IngressWatcher) IngressHandlerAddFunc(obj interface{}) {
-	host, path, functions, err := iw.extractIngressValuesFromIngressResource(obj)
+	host, path, targets, err := iw.extractIngressValuesFromIngressResource(obj)
 	if err != nil {
 		iw.logger.WarnWith("Add ingress handler failure", "error", err)
 		return
 	}
 
-	if err = iw.ingressCache.Set(host, path, functions); err != nil {
+	if err = iw.ingressCache.Set(host, path, targets); err != nil {
 		iw.logger.WarnWith("Add ingress handler failure- failed to add the new value", "error", err, "object", obj)
 		return
 	}
 }
 
 func (iw *IngressWatcher) IngressHandlerUpdateFunc(oldObj, newObj interface{}) {
-	oldHost, oldPath, oldFunctions, err := iw.extractIngressValuesFromIngressResource(oldObj)
+	oldHost, oldPath, oldTargets, err := iw.extractIngressValuesFromIngressResource(oldObj)
 	if err != nil {
 		iw.logger.WarnWith("Update ingress handler - failed to extract values from old object", "error", err)
 		return
 	}
 
-	newHost, newPath, newFunctions, err := iw.extractIngressValuesFromIngressResource(newObj)
+	newHost, newPath, newTargets, err := iw.extractIngressValuesFromIngressResource(newObj)
 	if err != nil {
 		iw.logger.WarnWith("Update ingress handler - failed to extract values from new object", "error", err)
 		return
 	}
 
-	//TODO - think on the scenarios here again TOMORROW
-	// The current implementation is- remove the old ingress and add the new one if the host, path or function name has changed
-
-	if err = iw.ingressCache.Delete(oldHost, oldPath, oldFunctions); err != nil {
-		iw.logger.WarnWith("Update ingress handler failure - failed to delete old ingress", "error", err)
+	// if the host or path has changed, we need to delete the old entry
+	if oldHost != newHost || oldPath != newPath {
+		if err = iw.ingressCache.Delete(oldHost, oldPath, oldTargets); err != nil {
+			iw.logger.WarnWith("Update ingress handler failure - failed to delete old ingress", "error", err)
+		}
 	}
 
-	//TODO - need to see how the ingress is being used in the cache- see the diff or only new ingress
-	if err = iw.ingressCache.Set(newHost, newPath, newFunctions); err != nil {
+	if err = iw.ingressCache.Set(newHost, newPath, newTargets); err != nil {
 		iw.logger.WarnWith("Update ingress handler failure- failed to add the new value", "error", err, "object", newObj)
 		return
 	}
 }
 
 func (iw *IngressWatcher) IngressHandlerDeleteFunc(obj interface{}) {
-	host, path, functions, err := iw.extractIngressValuesFromIngressResource(obj)
+	host, path, targets, err := iw.extractIngressValuesFromIngressResource(obj)
 	if err != nil {
 		iw.logger.WarnWith("Delete ingress handler failure- failed to extract values from object", "error", err)
 		return
 	}
 
-	if err = iw.ingressCache.Delete(host, path, functions); err != nil {
+	if err = iw.ingressCache.Delete(host, path, targets); err != nil {
 		iw.logger.WarnWith("Delete ingress handler failure- failed delete from cache", "error", err, "object", obj)
 		return
 	}
@@ -131,23 +136,82 @@ func (iw *IngressWatcher) IngressHandlerDeleteFunc(obj interface{}) {
 
 // --- internal methods ---
 
-// extractIngressValuesFromIngressResource extracts the host, path, and function name from the ingress resource.
+// extractIngressValuesFromIngressResource extracts the host, path, and targets from the ingress resource.
 func (iw *IngressWatcher) extractIngressValuesFromIngressResource(obj interface{}) (string, string, []string, error) {
 	ingress, ok := obj.(*networkingv1.Ingress)
 	if !ok {
 		return "", "", nil, errors.New("Failed to cast object to Ingress")
 	}
 
-	//todo - add function to extract host, path and function name from ingress resource
-	// For now, we just store WA
-	host, path, functions, err := iw.extractHostPathFunction(ingress)
+	host, path, targets, err := iw.extractHostPathTarget(ingress)
 	if err != nil {
-		return "", "", nil, errors.Wrap(err, "Failed to extract host, path and function from ingress")
+		return "", "", nil, errors.Wrap(err, "Failed to extract host, path and targets from ingress")
 	}
 
-	return host, path, functions, nil
+	return host, path, targets, nil
 }
 
-func (iw *IngressWatcher) extractHostPathFunction(ingress *networkingv1.Ingress) (string, string, []string, error) {
-	return "", "", nil, nil //todo - implement this function to extract host, path and function name from ingress resource
+// extractHostPathTarget extracts the host, path, and targets from the ingress resource
+func (iw *IngressWatcher) extractHostPathTarget(ingress *networkingv1.Ingress) (string, string, []string, error) {
+	host, err := iw.getHostFromIngress(ingress)
+	if err != nil {
+		return "", "", nil, errors.Wrap(err, "Failed to extract host from ingress")
+	}
+
+	path, err := iw.getPathFromIngress(ingress)
+	if err != nil {
+		return "", "", nil, errors.Wrap(err, "Failed to extract path from ingress")
+	}
+
+	targets, err := iw.resolveTargetsCallback(ingress)
+	if err != nil {
+		return "", "", nil, errors.Wrap(err, "Failed to extract targets from ingress labels")
+	}
+
+	return host, path, targets, nil
+}
+
+func (iw *IngressWatcher) getHostFromIngress(ingress *networkingv1.Ingress) (string, error) {
+	if ingress == nil {
+		return "", errors.New("ingress is nil")
+	}
+
+	if len(ingress.Spec.Rules) == 0 {
+		return "", errors.New("no rules found in ingress")
+	}
+
+	// Ingress must contain exactly one rule
+	rule := ingress.Spec.Rules[0]
+	if rule.Host == "" {
+		return "", errors.New("host is empty in ingress rule")
+	}
+
+	return rule.Host, nil
+}
+
+func (iw *IngressWatcher) getPathFromIngress(ingress *networkingv1.Ingress) (string, error) {
+	if ingress == nil {
+		return "", errors.New("ingress is nil")
+	}
+
+	if len(ingress.Spec.Rules) == 0 {
+		return "", errors.New("no rules found in ingress")
+	}
+
+	rule := ingress.Spec.Rules[0]
+	if rule.HTTP == nil {
+		return "", errors.New("no HTTP configuration found in ingress rule")
+	}
+
+	if len(rule.HTTP.Paths) == 0 {
+		return "", errors.New("no paths found in ingress HTTP rule")
+	}
+
+	// Ingress must contain exactly one rule
+	httpPath := rule.HTTP.Paths[0]
+	if httpPath.Path == "" {
+		return "", errors.New("path is empty in ingress HTTP rule")
+	}
+
+	return httpPath.Path, nil
 }

--- a/pkg/kube/ingress_test.go
+++ b/pkg/kube/ingress_test.go
@@ -1,0 +1,599 @@
+package kube
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/v3io/scaler/pkg/ingresscache"
+
+	"github.com/nuclio/logger"
+	nucliozap "github.com/nuclio/zap"
+	"github.com/stretchr/testify/suite"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+type IngressWatcherTestSuite struct {
+	suite.Suite
+	logger        logger.Logger
+	kubeClientSet *fake.Clientset
+}
+
+func (suite *IngressWatcherTestSuite) SetupSuite() {
+	suite.kubeClientSet = fake.NewSimpleClientset()
+}
+
+func (suite *IngressWatcherTestSuite) SetupTest() {
+	var err error
+
+	suite.logger, err = nucliozap.NewNuclioZapTest("test")
+	suite.Require().NoError(err)
+}
+
+// TestIngressWatcherTestSuite runs the test suite
+func TestIngressWatcherTestSuite(t *testing.T) {
+	suite.Run(t, new(IngressWatcherTestSuite))
+}
+
+func (suite *IngressWatcherTestSuite) TestIngressHandlerAddFunc() {
+	type ingressArgs struct {
+		host   string
+		path   string
+		target []string
+	}
+	for _, testCase := range []struct {
+		name              string
+		testArgs          ingressArgs
+		expectedResult    []string
+		initialStateCache *ingressArgs
+		errorMessage      string
+		expectError       bool
+	}{
+		{
+			name: "Add PairTarget",
+			testArgs: ingressArgs{
+				host:   "www.example.com",
+				path:   "/test/path",
+				target: []string{"test-targets-name-1", "test-targets-name-2"},
+			},
+			expectedResult: []string{"test-targets-name-1", "test-targets-name-2"},
+		}, {
+			name: "Add SingleTarget",
+			testArgs: ingressArgs{
+				host:   "www.example.com",
+				path:   "/test/path",
+				target: []string{"test-targets-name-1"},
+			},
+			expectedResult: []string{"test-targets-name-1"},
+		}, {
+			name: "Add SingleTarget with different name to the same host and path",
+			testArgs: ingressArgs{
+				host:   "www.example.com",
+				path:   "/test/path",
+				target: []string{"test-targets-name-2"},
+			},
+			expectedResult: []string{"test-targets-name-2"},
+			initialStateCache: &ingressArgs{
+				host:   "www.example.com",
+				path:   "/test/path",
+				target: []string{"test-targets-name-1"},
+			},
+		}, {
+			name: "bad input- should fail",
+			testArgs: ingressArgs{
+				host:   "www.example.com",
+				path:   "/test/path",
+				target: []string{"test-targets-name-2"},
+			},
+			expectedResult: []string{},
+			expectError:    true,
+			errorMessage:   "host does not exist",
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			var testObj interface{}
+			testIngressWatcher, err := suite.createTestIngressWatcher()
+			suite.Require().NoError(err)
+
+			testObj = suite.createDummyIngress(testCase.testArgs.host, testCase.testArgs.path, testCase.testArgs.target)
+
+			if testCase.expectError {
+				testObj = &networkingv1.IngressSpec{}
+			}
+
+			if testCase.initialStateCache != nil {
+				err = testIngressWatcher.ingressCache.Set(testCase.initialStateCache.host, testCase.initialStateCache.path, testCase.initialStateCache.target)
+				suite.Require().NoError(err)
+			}
+
+			testIngressWatcher.IngressHandlerAddFunc(testObj)
+			// get the targets from the cache and compare values
+			resultTargetNames, err := testIngressWatcher.ingressCache.Get(testCase.testArgs.host, testCase.testArgs.path)
+			if testCase.expectError {
+				suite.Require().Error(err)
+				suite.Require().ErrorContains(err, testCase.errorMessage)
+				suite.Require().Nil(resultTargetNames)
+			} else {
+				suite.Require().NoError(err)
+				suite.Require().Equal(testCase.expectedResult, resultTargetNames)
+			}
+		})
+	}
+}
+
+func (suite *IngressWatcherTestSuite) TestIngressHandlerUpdateFunc() {
+	type ingressArgs struct {
+		host    string
+		path    string
+		targets []string
+	}
+	type expectedResults struct {
+		host           string
+		path           string
+		targets        []string
+		expectError    bool
+		expectErrorMsg string
+	}
+	for _, testCase := range []struct {
+		name              string
+		expectedResults   []expectedResults
+		initialStateCache *ingressArgs
+		testOldObj        ingressArgs
+		testNewObj        ingressArgs
+	}{
+		{
+			name: "Update PairTarget - same host and path, different Targets",
+			expectedResults: []expectedResults{
+				{
+					host:    "www.example.com",
+					path:    "/test/path",
+					targets: []string{"test-targets-name-1", "test-targets-name-3"},
+				},
+			},
+			testOldObj: ingressArgs{
+				host:    "www.example.com",
+				path:    "/test/path",
+				targets: []string{"test-targets-name-1", "test-targets-name-2"},
+			},
+			testNewObj: ingressArgs{
+				host:    "www.example.com",
+				path:    "/test/path",
+				targets: []string{"test-targets-name-1", "test-targets-name-3"},
+			},
+			initialStateCache: &ingressArgs{
+				host:    "www.example.com",
+				path:    "/test/path",
+				targets: []string{"test-targets-name-1", "test-targets-name-2"},
+			},
+		}, {
+			name: "Update PairTarget - different path- should Delete old Targets",
+			initialStateCache: &ingressArgs{
+				host:    "www.example.com",
+				path:    "/test/path",
+				targets: []string{"test-targets-name-1", "test-targets-name-2"},
+			},
+			testOldObj: ingressArgs{
+				host:    "www.example.com",
+				path:    "/test/path",
+				targets: []string{"test-targets-name-1", "test-targets-name-2"},
+			},
+			testNewObj: ingressArgs{
+				host:    "www.example.com",
+				path:    "/another/path",
+				targets: []string{"test-targets-name-1", "test-targets-name-2"},
+			},
+			expectedResults: []expectedResults{
+				{
+					host:           "www.example.com",
+					path:           "/test/path",
+					expectError:    true,
+					expectErrorMsg: "failed to get the targets from the ingress host tree",
+				}, {
+					host:    "www.example.com",
+					path:    "/another/path",
+					targets: []string{"test-targets-name-1", "test-targets-name-2"},
+				},
+			},
+		}, {
+			name: "Update PairTarget - different host- should Delete old Targets",
+			initialStateCache: &ingressArgs{
+				host:    "www.example.com",
+				path:    "/test/path",
+				targets: []string{"test-targets-name-1", "test-targets-name-2"},
+			},
+			testOldObj: ingressArgs{
+				host:    "www.example.com",
+				path:    "/test/path",
+				targets: []string{"test-targets-name-1", "test-targets-name-2"},
+			},
+			testNewObj: ingressArgs{
+				host:    "www.google.com",
+				path:    "/test/path",
+				targets: []string{"test-targets-name-1", "test-targets-name-2"},
+			},
+			expectedResults: []expectedResults{
+				{
+					host:           "www.example.com",
+					path:           "/test/path",
+					expectError:    true,
+					expectErrorMsg: "host does not exist",
+				}, {
+					host:    "www.google.com",
+					path:    "/test/path",
+					targets: []string{"test-targets-name-1", "test-targets-name-2"},
+				},
+			},
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			testIngressWatcher, err := suite.createTestIngressWatcher()
+			suite.Require().NoError(err)
+
+			testOldObj := suite.createDummyIngress(testCase.testOldObj.host, testCase.testOldObj.path, testCase.testOldObj.targets)
+			testNewObj := suite.createDummyIngress(testCase.testNewObj.host, testCase.testNewObj.path, testCase.testNewObj.targets)
+
+			if testCase.initialStateCache != nil {
+				err = testIngressWatcher.ingressCache.Set(testCase.initialStateCache.host, testCase.initialStateCache.path, testCase.initialStateCache.targets)
+				suite.Require().NoError(err)
+			}
+
+			testIngressWatcher.IngressHandlerUpdateFunc(testOldObj, testNewObj)
+
+			// iterate over the expectedResults to check the results for each host and path
+			for _, expectedResult := range testCase.expectedResults {
+				resultTargetNames, err := testIngressWatcher.ingressCache.Get(expectedResult.host, expectedResult.path)
+				if expectedResult.expectError {
+					suite.Require().Error(err)
+					suite.Require().ErrorContains(err, expectedResult.expectErrorMsg)
+					suite.Require().Nil(resultTargetNames)
+				} else {
+					suite.Require().NoError(err)
+					suite.Require().Equal(expectedResult.targets, resultTargetNames)
+				}
+			}
+		})
+	}
+}
+
+func (suite *IngressWatcherTestSuite) TestIngressHandlerDeleteFunc() {
+	type ingressArgs struct {
+		host    string
+		path    string
+		targets []string
+	}
+	type expectedResult struct {
+		host           string
+		path           string
+		targets        []string
+		expectError    bool
+		expectErrorMsg string
+	}
+	for _, testCase := range []struct {
+		name              string
+		testArgs          ingressArgs
+		expectedResult    expectedResult
+		initialStateCache *ingressArgs
+		errorMessage      string
+		expectError       bool
+	}{
+		{
+			name: "Delete PairTarget",
+			initialStateCache: &ingressArgs{
+				host:    "www.example.com",
+				path:    "/test/path",
+				targets: []string{"test-targets-name-1", "test-targets-name-2"},
+			},
+			testArgs: ingressArgs{
+				host:    "www.example.com",
+				path:    "/test/path",
+				targets: []string{"test-targets-name-1", "test-targets-name-2"},
+			},
+			expectedResult: expectedResult{
+				host:           "www.example.com",
+				path:           "/test/path",
+				targets:        nil,
+				expectError:    true,
+				expectErrorMsg: "host does not exist",
+			},
+		}, {
+			name: "Delete SingleTarget",
+			initialStateCache: &ingressArgs{
+				host:    "www.example.com",
+				path:    "/test/path",
+				targets: []string{"test-targets-name-1"},
+			},
+			testArgs: ingressArgs{
+				host:    "www.example.com",
+				path:    "/test/path",
+				targets: []string{"test-targets-name-1"},
+			},
+			expectedResult: expectedResult{
+				host:           "www.example.com",
+				path:           "/test/path",
+				targets:        nil,
+				expectError:    true,
+				expectErrorMsg: "host does not exist",
+			},
+		}, {
+			name: "bad input- should fail and keep the cache as is",
+			initialStateCache: &ingressArgs{
+				host:    "www.example.com",
+				path:    "/test/path",
+				targets: []string{"test-targets-name-1"},
+			},
+			testArgs: ingressArgs{
+				host:    "www.example.com",
+				path:    "/test/path",
+				targets: []string{"test-targets-name-2"},
+			},
+			expectedResult: expectedResult{
+				host:    "www.example.com",
+				path:    "/test/path",
+				targets: []string{"test-targets-name-1"},
+			},
+			expectError:  true,
+			errorMessage: "host does not exist",
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			var testObj interface{}
+			testIngressWatcher, err := suite.createTestIngressWatcher()
+			suite.Require().NoError(err)
+
+			testObj = suite.createDummyIngress(testCase.testArgs.host, testCase.testArgs.path, testCase.testArgs.targets)
+
+			if testCase.expectError {
+				testObj = &networkingv1.IngressSpec{}
+			}
+
+			if testCase.initialStateCache != nil {
+				err = testIngressWatcher.ingressCache.Set(testCase.initialStateCache.host, testCase.initialStateCache.path, testCase.initialStateCache.targets)
+				suite.Require().NoError(err)
+			}
+
+			testIngressWatcher.IngressHandlerDeleteFunc(testObj)
+			// get the targets from the cache and compare values
+			resultTargetNames, err := testIngressWatcher.ingressCache.Get(testCase.expectedResult.host, testCase.expectedResult.path)
+			if testCase.expectedResult.expectError {
+				suite.Require().Error(err)
+				suite.Require().ErrorContains(err, testCase.expectedResult.expectErrorMsg)
+				suite.Require().Nil(resultTargetNames)
+			} else {
+				suite.Require().NoError(err)
+				suite.Require().Equal(testCase.expectedResult.targets, resultTargetNames)
+			}
+		})
+	}
+}
+
+func (suite *IngressWatcherTestSuite) TestGetPathFromIngress() {
+	type testCase struct {
+		name        string
+		ingress     *networkingv1.Ingress
+		expected    string
+		expectError bool
+		errorMsg    string
+	}
+	tests := []testCase{
+		{
+			name:     "Valid ingress with path",
+			ingress:  suite.createDummyIngress("host", "/test", []string{"target"}),
+			expected: "/test",
+		},
+		{
+			name:        "Nil ingress",
+			ingress:     nil,
+			expectError: true,
+			errorMsg:    "ingress is nil",
+		},
+		{
+			name:        "No rules",
+			ingress:     &networkingv1.Ingress{},
+			expectError: true,
+			errorMsg:    "no rules found in ingress",
+		},
+		{
+			name: "Nil HTTP",
+			ingress: &networkingv1.Ingress{
+				Spec: networkingv1.IngressSpec{
+					Rules: []networkingv1.IngressRule{{}},
+				},
+			},
+			expectError: true,
+			errorMsg:    "no HTTP configuration found in ingress rule",
+		},
+		{
+			name: "No paths",
+			ingress: &networkingv1.Ingress{
+				Spec: networkingv1.IngressSpec{
+					Rules: []networkingv1.IngressRule{
+						{
+							IngressRuleValue: networkingv1.IngressRuleValue{
+								HTTP: &networkingv1.HTTPIngressRuleValue{},
+							},
+						},
+					},
+				},
+			},
+			expectError: true,
+			errorMsg:    "no paths found in ingress HTTP rule",
+		},
+		{
+			name: "Empty path",
+			ingress: &networkingv1.Ingress{
+				Spec: networkingv1.IngressSpec{
+					Rules: []networkingv1.IngressRule{
+						{
+							IngressRuleValue: networkingv1.IngressRuleValue{
+								HTTP: &networkingv1.HTTPIngressRuleValue{
+									Paths: []networkingv1.HTTPIngressPath{
+										{Path: ""},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectError: true,
+			errorMsg:    "path is empty in ingress HTTP rule",
+		},
+	}
+
+	watcher, _ := suite.createTestIngressWatcher()
+	for _, tc := range tests {
+		suite.Run(tc.name, func() {
+			path, err := watcher.getPathFromIngress(tc.ingress)
+			if tc.expectError {
+				suite.Require().Error(err)
+				suite.Require().ErrorContains(err, tc.errorMsg)
+				suite.Require().Empty(path)
+			} else {
+				suite.Require().NoError(err)
+				suite.Require().Equal(tc.expected, path)
+			}
+		})
+	}
+}
+
+func (suite *IngressWatcherTestSuite) TestGetHostFromIngress() {
+	for _, testCase := range []struct {
+		name        string
+		ingress     *networkingv1.Ingress
+		expected    string
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name:     "Valid ingress with host",
+			ingress:  suite.createDummyIngress("test-host", "/test", []string{"target"}),
+			expected: "test-host",
+		},
+		{
+			name:        "Nil ingress",
+			ingress:     nil,
+			expectError: true,
+			errorMsg:    "ingress is nil",
+		},
+		{
+			name:        "No rules",
+			ingress:     &networkingv1.Ingress{},
+			expectError: true,
+			errorMsg:    "no rules found in ingress",
+		},
+		{
+			name: "Empty host",
+			ingress: &networkingv1.Ingress{
+				Spec: networkingv1.IngressSpec{
+					Rules: []networkingv1.IngressRule{
+						{
+							IngressRuleValue: networkingv1.IngressRuleValue{
+								HTTP: &networkingv1.HTTPIngressRuleValue{
+									Paths: []networkingv1.HTTPIngressPath{
+										{Path: "/test"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectError: true,
+			errorMsg:    "host is empty in ingress rule",
+		},
+	} {
+		testIngressWatcher, err := suite.createTestIngressWatcher()
+		suite.Require().NoError(err)
+
+		suite.Run(testCase.name, func() {
+			host, err := testIngressWatcher.getHostFromIngress(testCase.ingress)
+			if testCase.expectError {
+				suite.Require().Error(err)
+				suite.Require().ErrorContains(err, testCase.errorMsg)
+				suite.Require().Empty(host)
+			} else {
+				suite.Require().NoError(err)
+				suite.Require().Equal(testCase.expected, host)
+			}
+		})
+
+	}
+}
+
+// --- IngressWatcherTestSuite suite methods ---
+
+// Create a dummy IngressWatcher for testing
+func (suite *IngressWatcherTestSuite) createTestIngressWatcher() (*IngressWatcher, error) {
+
+	ctx := context.Background()
+
+	return NewIngressWatcher(ctx,
+		suite.logger,
+		suite.kubeClientSet,
+		ingresscache.NewIngressCache(suite.logger),
+		suite.createMockResolveFunc(),
+		"test-namespace",
+		"test-labels-filter",
+	)
+}
+
+func (suite *IngressWatcherTestSuite) createMockResolveFunc() ResolveTargetsFromIngressCallback {
+	return func(ingress *networkingv1.Ingress) ([]string, error) {
+		// Extract targets from ingress - matches createDummyIngress structure (1 rule, 1 path)
+		if len(ingress.Spec.Rules) != 1 {
+			return []string{}, nil
+		}
+
+		rule := ingress.Spec.Rules[0]
+		if rule.HTTP == nil {
+			return []string{}, nil
+		}
+
+		if len(rule.HTTP.Paths) != 1 {
+			return []string{}, nil
+		}
+
+		path := rule.HTTP.Paths[0]
+		if path.Backend.Service == nil {
+			return []string{}, nil
+		}
+
+		target := path.Backend.Service.Name
+		// targets might have ',' as a delimiter in the annotation case
+		return strings.Split(target, ","), nil
+	}
+}
+
+// createDummyIngress Creates a dummy Ingress object for testing
+func (suite *IngressWatcherTestSuite) createDummyIngress(host, path string, targets []string) *networkingv1.Ingress {
+	target := strings.Join(targets, ",")
+	return &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-ingress",
+			Namespace: "test-namespace",
+		},
+		Spec: networkingv1.IngressSpec{
+			Rules: []networkingv1.IngressRule{
+				{
+					Host: host,
+					IngressRuleValue: networkingv1.IngressRuleValue{
+						HTTP: &networkingv1.HTTPIngressRuleValue{
+							Paths: []networkingv1.HTTPIngressPath{
+								{
+									Path: path,
+									Backend: networkingv1.IngressBackend{
+										Service: &networkingv1.IngressServiceBackend{
+											Name: target,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/kube/ingress_test.go
+++ b/pkg/kube/ingress_test.go
@@ -1,3 +1,23 @@
+/*
+Copyright 2025 Iguazio Systems Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License") with
+an addition restriction as set forth herein. You may not use this
+file except in compliance with the License. You may obtain a copy of
+the License at http://www.apache.org/licenses/LICENSE-2.0.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing
+permissions and limitations under the License.
+
+In addition, you may not use the software for any purposes that are
+illegal under applicable law, and the grant of the foregoing license
+under the Apache 2.0 license is conditioned upon your compliance with
+such restriction.
+*/
+
 package kube
 
 import (


### PR DESCRIPTION
### **Description**  
Full description in the LLD that linked to this Jira - https://iguazio.atlassian.net/browse/NUC-498
This PR introduces a new IngressWatcher component that uses Kubernetes informers to watch for Ingress resource changes and updates an internal IngressHostCache accordingly. The watcher handles add, update, and delete events, extracts relevant data (host, path, target list), and reflects those changes in the in-memory cache.

### **Affected Areas**  
- `pkg/kube/ingress.go` – new file with the IngressWatcher implementation
- Uses `IngressHostCache` from `pkg/ingresscache`
- Integrates with `k8s.io/client-go` for informers

### **Testing**  
- Unit tests coverage for all event handler paths (add, update, delete) correctly modify the ingress cache.
- Unit tests validates cache sync behavior and logging of edge cases (e.g., missing host/path).
- Integrations tests are out of scope for this PR, will be introduced as part of the code changes in `Nuclio`

### **Changes Made**  
- Added `IngressWatcher` struct to manage and respond to Kubernetes Ingress resource changes.
- Implemented handlers for Add, Update, and Delete events.
- Extracted ingress data: host, path, targets via helper methods.
- Registered shared informer factory with label selector support.

### **Additional notes** 
- Assumes each Ingress contains exactly one rule and one path.
- Includes detailed error logging for resilience and observability.
- Additional PR for integrating the ingress cache and ingress watcher is needed