### PR TITLE
[DLX] Integrate cache and watcher into dlx struct

### DIFF
--- a/cmd/autoscaler/app/autoscaler.go
+++ b/cmd/autoscaler/app/autoscaler.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/v3io/scaler/pkg/autoscaler"
+	"github.com/v3io/scaler/pkg/common"
 	"github.com/v3io/scaler/pkg/pluginloader"
 	"github.com/v3io/scaler/pkg/scalertypes"
 
@@ -35,7 +36,6 @@ import (
 	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
-	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/metrics/pkg/client/custom_metrics"
 )
 
@@ -73,7 +73,7 @@ func Run(kubeconfigPath string,
 		autoScalerOptions = resourceScalerConfig.AutoScalerOptions
 	}
 
-	restConfig, err := getClientConfig(kubeconfigPath)
+	restConfig, err := common.GetClientConfig(kubeconfigPath)
 	if err != nil {
 		return errors.Wrap(err, "Failed to get client configuration")
 	}
@@ -118,12 +118,4 @@ func createAutoScaler(restConfig *rest.Config,
 	}
 
 	return newScaler, nil
-}
-
-func getClientConfig(kubeconfigPath string) (*rest.Config, error) {
-	if kubeconfigPath != "" {
-		return clientcmd.BuildConfigFromFlags("", kubeconfigPath)
-	}
-
-	return rest.InClusterConfig()
 }

--- a/cmd/dlx/app/dlx.go
+++ b/cmd/dlx/app/dlx.go
@@ -82,8 +82,7 @@ func Run(kubeconfigPath string,
 		return errors.Wrap(err, "Failed to get client configuration")
 	}
 
-	dlxOptions.KubeClientSet, err = kubernetes.NewForConfig(restConfig)
-	if err != nil {
+	if dlxOptions.KubeClientSet, err = kubernetes.NewForConfig(restConfig); err != nil {
 		return errors.Wrap(err, "Failed to create k8s client set")
 	}
 

--- a/cmd/dlx/app/dlx.go
+++ b/cmd/dlx/app/dlx.go
@@ -82,12 +82,12 @@ func Run(kubeconfigPath string,
 		return errors.Wrap(err, "Failed to get client configuration")
 	}
 
-	kubeClientSet, err := kubernetes.NewForConfig(restConfig)
+	dlxOptions.KubeClientSet, err = kubernetes.NewForConfig(restConfig)
 	if err != nil {
 		return errors.Wrap(err, "Failed to create k8s client set")
 	}
 
-	newDLX, err := createDLX(resourceScaler, dlxOptions, kubeClientSet)
+	newDLX, err := createDLX(resourceScaler, dlxOptions)
 	if err != nil {
 		return errors.Wrap(err, "Failed to create dlx")
 	}
@@ -103,7 +103,6 @@ func Run(kubeconfigPath string,
 func createDLX(
 	resourceScaler scalertypes.ResourceScaler,
 	options scalertypes.DLXOptions,
-	kubeClientSet kubernetes.Interface,
 ) (*dlx.DLX, error) {
 	rootLogger, err := nucliozap.NewNuclioZap("scaler",
 		"console",
@@ -115,7 +114,7 @@ func createDLX(
 		return nil, errors.Wrap(err, "Failed to initialize root logger")
 	}
 
-	newScaler, err := dlx.NewDLX(rootLogger, resourceScaler, options, kubeClientSet)
+	newScaler, err := dlx.NewDLX(rootLogger, resourceScaler, options)
 
 	if err != nil {
 		return nil, err

--- a/pkg/common/helpers.go
+++ b/pkg/common/helpers.go
@@ -23,6 +23,9 @@ package common
 import (
 	"math/rand"
 	"time"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 var SeededRand = rand.New(rand.NewSource(time.Now().UnixNano()))
@@ -37,4 +40,12 @@ func UniquifyStringSlice(stringList []string) []string {
 		}
 	}
 	return list
+}
+
+func GetClientConfig(kubeconfigPath string) (*rest.Config, error) {
+	if kubeconfigPath != "" {
+		return clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+	}
+
+	return rest.InClusterConfig()
 }

--- a/pkg/dlx/dlx.go
+++ b/pkg/dlx/dlx.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
+	"k8s.io/client-go/kubernetes"
 )
 
 type DLX struct {
@@ -38,7 +39,9 @@ type DLX struct {
 
 func NewDLX(parentLogger logger.Logger,
 	resourceScaler scalertypes.ResourceScaler,
-	options scalertypes.DLXOptions) (*DLX, error) {
+	options scalertypes.DLXOptions,
+	kubeClientSet kubernetes.Interface,
+) (*DLX, error) {
 	childLogger := parentLogger.GetChild("dlx")
 	childLogger.InfoWith("Creating DLX",
 		"options", options)

--- a/pkg/dlx/dlx.go
+++ b/pkg/dlx/dlx.go
@@ -36,7 +36,6 @@ type DLX struct {
 	logger  logger.Logger
 	handler Handler
 	server  *http.Server
-	cache   ingresscache.IngressHostCache
 	watcher *kube.IngressWatcher
 }
 
@@ -86,7 +85,6 @@ func NewDLX(parentLogger logger.Logger,
 		server: &http.Server{
 			Addr: options.ListenAddress,
 		},
-		cache:   cache,
 		watcher: watcher,
 	}, nil
 }

--- a/pkg/dlx/dlx.go
+++ b/pkg/dlx/dlx.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
-	"k8s.io/client-go/kubernetes"
 )
 
 type DLX struct {
@@ -43,9 +42,7 @@ type DLX struct {
 
 func NewDLX(parentLogger logger.Logger,
 	resourceScaler scalertypes.ResourceScaler,
-	options scalertypes.DLXOptions,
-	kubeClientSet kubernetes.Interface,
-) (*DLX, error) {
+	options scalertypes.DLXOptions) (*DLX, error) {
 	childLogger := parentLogger.GetChild("dlx")
 	childLogger.InfoWith("Creating DLX",
 		"options", options)
@@ -72,7 +69,7 @@ func NewDLX(parentLogger logger.Logger,
 	watcher, err := kube.NewIngressWatcher(
 		context.Background(),
 		childLogger,
-		kubeClientSet,
+		options.KubeClientSet,
 		cache,
 		options.ResolveTargetsFromIngressCallback,
 		options.ResyncInterval,

--- a/pkg/ingresscache/ingresscache.go
+++ b/pkg/ingresscache/ingresscache.go
@@ -35,7 +35,7 @@ type IngressCache struct {
 func NewIngressCache(logger logger.Logger) *IngressCache {
 	return &IngressCache{
 		syncMap: &sync.Map{},
-		logger:  logger,
+		logger:  logger.GetChild("cache"),
 	}
 }
 

--- a/pkg/ingresscache/types.go
+++ b/pkg/ingresscache/types.go
@@ -20,15 +20,19 @@ such restriction.
 
 package ingresscache
 
+type IngressHostCacheReader interface {
+	// Get retrieves all target names for the given host and path
+	Get(host string, path string) ([]string, error)
+}
+
 type IngressHostCache interface {
+	IngressHostCacheReader
+
 	// Set adds a new item to the cache for the given host, path and targets. Will overwrite existing values if any
 	Set(host string, path string, targets []string) error
 
 	// Delete removes the specified targets from the cache for the given host and path. Will do nothing if host, path or targets do not exist
 	Delete(host string, path string, targets []string) error
-
-	// Get retrieves all target names for the given host and path
-	Get(host string, path string) ([]string, error)
 }
 
 type IngressHostsTree interface {

--- a/pkg/kube/ingress.go
+++ b/pkg/kube/ingress.go
@@ -57,7 +57,6 @@ func NewIngressWatcher(
 	dlxCtx context.Context,
 	dlxLogger logger.Logger,
 	kubeClient kubernetes.Interface,
-	ingressCache ingresscache.IngressHostCache,
 	resolveTargetsCallback scalertypes.ResolveTargetsFromIngressCallback,
 	resyncInterval scalertypes.Duration,
 	namespace string,
@@ -83,7 +82,7 @@ func NewIngressWatcher(
 		ctx:                    ctxWithCancel,
 		cancel:                 cancel,
 		logger:                 dlxLogger.GetChild("watcher"),
-		cache:                  ingressCache,
+		cache:                  ingresscache.NewIngressCache(dlxLogger),
 		factory:                factory,
 		informer:               ingressInformer,
 		resolveTargetsCallback: resolveTargetsCallback,
@@ -117,6 +116,11 @@ func (iw *IngressWatcher) Stop() {
 	iw.logger.Info("Stopping ingress watcher")
 	iw.cancel()
 	iw.factory.Shutdown()
+}
+
+// GetIngressHostCacheReader expose read-only access to the ingress cache
+func (iw *IngressWatcher) GetIngressHostCacheReader() ingresscache.IngressHostCacheReader {
+	return iw.cache
 }
 
 // --- ResourceEventHandler methods ---

--- a/pkg/kube/ingress_test.go
+++ b/pkg/kube/ingress_test.go
@@ -117,7 +117,7 @@ func (suite *IngressWatcherTestSuite) TestAddHandler() {
 			testIngressWatcher, err := suite.createTestIngressWatcher()
 			suite.Require().NoError(err)
 
-			testObj = suite.createDummyIngress(testCase.testArgs.host, testCase.testArgs.path, testCase.testArgs.version, testCase.testArgs.targets)
+			testObj = suite.createDummyIngress(testCase.testArgs.host, testCase.testArgs.path, "1", testCase.testArgs.targets)
 
 			if testCase.expectError {
 				testObj = &networkingv1.IngressSpec{}
@@ -150,6 +150,8 @@ func (suite *IngressWatcherTestSuite) TestUpdateHandler() {
 		initialCachedData *ingressValue
 		testOldObj        ingressValue
 		testNewObj        ingressValue
+		OldObjVersion     string
+		newObjVersion     string
 	}{
 		{
 			name: "Update PairTarget - same host and path, different targets",
@@ -163,15 +165,15 @@ func (suite *IngressWatcherTestSuite) TestUpdateHandler() {
 			testOldObj: ingressValue{
 				host:    "www.example.com",
 				path:    "/test/path",
-				version: "1",
 				targets: []string{"test-targets-name-1", "test-targets-name-2"},
 			},
+			OldObjVersion: "1",
 			testNewObj: ingressValue{
 				host:    "www.example.com",
 				path:    "/test/path",
-				version: "2",
 				targets: []string{"test-targets-name-1", "test-targets-name-3"},
 			},
+			newObjVersion: "2",
 			initialCachedData: &ingressValue{
 				host:    "www.example.com",
 				path:    "/test/path",
@@ -189,15 +191,15 @@ func (suite *IngressWatcherTestSuite) TestUpdateHandler() {
 			testOldObj: ingressValue{
 				host:    "www.example.com",
 				path:    "/test/path",
-				version: "1",
 				targets: []string{"test-targets-name-1", "test-targets-name-2"},
 			},
 			testNewObj: ingressValue{
 				host:    "www.example.com",
 				path:    "/test/path",
-				version: "1",
 				targets: []string{"test-targets-name-1", "test-targets-name-3"},
 			},
+			OldObjVersion: "1",
+			newObjVersion: "1",
 			initialCachedData: &ingressValue{
 				host:    "www.example.com",
 				path:    "/test/path",
@@ -213,15 +215,15 @@ func (suite *IngressWatcherTestSuite) TestUpdateHandler() {
 			testOldObj: ingressValue{
 				host:    "www.example.com",
 				path:    "/test/path",
-				version: "1",
 				targets: []string{"test-targets-name-1", "test-targets-name-2"},
 			},
+			OldObjVersion: "1",
 			testNewObj: ingressValue{
 				host:    "www.example.com",
 				path:    "/another/path",
-				version: "2",
 				targets: []string{"test-targets-name-1", "test-targets-name-2"},
 			},
+			newObjVersion: "2",
 			expectedResults: []expectedResult{
 				{
 					host:           "www.example.com",
@@ -244,15 +246,15 @@ func (suite *IngressWatcherTestSuite) TestUpdateHandler() {
 			testOldObj: ingressValue{
 				host:    "www.example.com",
 				path:    "/test/path",
-				version: "1",
 				targets: []string{"test-targets-name-1", "test-targets-name-2"},
 			},
+			OldObjVersion: "1",
 			testNewObj: ingressValue{
 				host:    "www.google.com",
 				path:    "/test/path",
-				version: "2",
 				targets: []string{"test-targets-name-1", "test-targets-name-2"},
 			},
+			newObjVersion: "2",
 			expectedResults: []expectedResult{
 				{
 					host:           "www.example.com",
@@ -271,8 +273,8 @@ func (suite *IngressWatcherTestSuite) TestUpdateHandler() {
 			testIngressWatcher, err := suite.createTestIngressWatcher()
 			suite.Require().NoError(err)
 
-			testOldObj := suite.createDummyIngress(testCase.testOldObj.host, testCase.testOldObj.path, testCase.testOldObj.version, testCase.testOldObj.targets)
-			testNewObj := suite.createDummyIngress(testCase.testNewObj.host, testCase.testNewObj.path, testCase.testNewObj.version, testCase.testNewObj.targets)
+			testOldObj := suite.createDummyIngress(testCase.testOldObj.host, testCase.testOldObj.path, testCase.OldObjVersion, testCase.testOldObj.targets)
+			testNewObj := suite.createDummyIngress(testCase.testNewObj.host, testCase.testNewObj.path, testCase.newObjVersion, testCase.testNewObj.targets)
 
 			if testCase.initialCachedData != nil {
 				err = testIngressWatcher.cache.Set(testCase.initialCachedData.host, testCase.initialCachedData.path, testCase.initialCachedData.targets)
@@ -370,7 +372,7 @@ func (suite *IngressWatcherTestSuite) TestDeleteHandler() {
 			testIngressWatcher, err := suite.createTestIngressWatcher()
 			suite.Require().NoError(err)
 
-			testObj = suite.createDummyIngress(testCase.testArgs.host, testCase.testArgs.path, testCase.testArgs.version, testCase.testArgs.targets)
+			testObj = suite.createDummyIngress(testCase.testArgs.host, testCase.testArgs.path, "1", testCase.testArgs.targets)
 
 			if testCase.expectError {
 				testObj = &networkingv1.IngressSpec{}

--- a/pkg/kube/ingress_test.go
+++ b/pkg/kube/ingress_test.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/v3io/scaler/pkg/ingresscache"
 	"github.com/v3io/scaler/pkg/scalertypes"
 
 	"github.com/nuclio/logger"
@@ -562,7 +561,6 @@ func (suite *IngressWatcherTestSuite) createTestIngressWatcher() (*IngressWatche
 	return NewIngressWatcher(ctx,
 		suite.logger,
 		suite.kubeClientSet,
-		ingresscache.NewIngressCache(suite.logger),
 		suite.createMockResolveFunc(),
 		scalertypes.Duration{},
 		"test-namespace",

--- a/pkg/scalertypes/types.go
+++ b/pkg/scalertypes/types.go
@@ -30,6 +30,7 @@ import (
 	"github.com/nuclio/errors"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes"
 )
 
 type AutoScalerOptions struct {
@@ -88,6 +89,7 @@ type DLXOptions struct {
 	LabelSelector                     string
 	ResolveTargetsFromIngressCallback ResolveTargetsFromIngressCallback `json:"-"`
 	ResyncInterval                    Duration
+	KubeClientSet                     kubernetes.Interface `json:"-"`
 }
 
 type ResourceScaler interface {


### PR DESCRIPTION
### Description  
This PR integrates the cache and watcher components into the DLX to enable scale-from-zero functionality based on ingress resources rather than relying on request headers. 

### Changes Made  
- Refactored initialization logic in both the ingress cache and ingress watcher operator to support external usage from the DLX.
- Integrated `ingresscache.IngressHostCache` and `kube.IngressWatcher` into the DLX.
- Optimize the watcher's `UpdateHandler` by adding a fast exit when the old and new objects share the same `ResourceVersion`

### References  
- Jira ticket link - https://iguazio.atlassian.net/browse/NUC-510

### Additional Notes  
- This task will be ready for review once manual testing is complete, including the Nuclio side.
- A separate ticket will handle integrating the cache into the `requestHandler` as part of completing the full solution