### PR TITLE
[Handler] Integrate the watcher's cache into request handler

### DIFF
--- a/pkg/dlx/dlx.go
+++ b/pkg/dlx/dlx.go
@@ -71,7 +71,8 @@ func NewDLX(parentLogger logger.Logger,
 		options.TargetNameHeader,
 		options.TargetPathHeader,
 		options.TargetPort,
-		options.MultiTargetStrategy)
+		options.MultiTargetStrategy,
+		watcher.GetIngressHostCacheReader())
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create handler")
 	}

--- a/pkg/dlx/handler.go
+++ b/pkg/dlx/handler.go
@@ -30,6 +30,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/v3io/scaler/pkg/ingresscache"
 	"github.com/v3io/scaler/pkg/scalertypes"
 
 	"github.com/nuclio/errors"
@@ -49,6 +50,7 @@ type Handler struct {
 	targetURLCache      *cache.LRUExpireCache
 	proxyLock           sync.Locker
 	lastProxyErrorTime  time.Time
+	ingressCache        ingresscache.IngressHostCacheReader
 }
 
 func NewHandler(parentLogger logger.Logger,
@@ -57,7 +59,8 @@ func NewHandler(parentLogger logger.Logger,
 	targetNameHeader string,
 	targetPathHeader string,
 	targetPort int,
-	multiTargetStrategy scalertypes.MultiTargetStrategy) (Handler, error) {
+	multiTargetStrategy scalertypes.MultiTargetStrategy,
+	ingressCache ingresscache.IngressHostCacheReader) (Handler, error) {
 	h := Handler{
 		logger:              parentLogger.GetChild("handler"),
 		resourceStarter:     resourceStarter,
@@ -69,6 +72,7 @@ func NewHandler(parentLogger logger.Logger,
 		targetURLCache:      cache.NewLRUExpireCache(100),
 		proxyLock:           &sync.Mutex{},
 		lastProxyErrorTime:  time.Now(),
+		ingressCache:        ingressCache,
 	}
 	h.HandleFunc = h.handleRequest
 	return h, nil

--- a/pkg/dlx/handler.go
+++ b/pkg/dlx/handler.go
@@ -105,7 +105,7 @@ func (h *Handler) handleRequest(res http.ResponseWriter, req *http.Request) {
 			h.logger.WarnWith("Failed to get resource names and path from request",
 				"error", err.Error(),
 				"host", req.Host,
-				"path", req.URL.Path)
+				"path", h.getRequestURLPath(req))
 			res.WriteHeader(http.StatusBadRequest)
 			return
 		}
@@ -175,7 +175,7 @@ func (h *Handler) getPathAndResourceNames(req *http.Request) (string, []string, 
 
 	h.logger.DebugWith("Failed to get resource names from ingress cache, trying to extract from the request headers",
 		"host", req.Host,
-		"path", req.URL.Path,
+		"path", h.getRequestURLPath(req),
 		"error", err.Error())
 
 	// old implementation for backward compatibility
@@ -190,7 +190,7 @@ func (h *Handler) getPathAndResourceNames(req *http.Request) (string, []string, 
 
 func (h *Handler) getValuesFromCache(req *http.Request) (string, []string, error) {
 	host := req.Host
-	path := req.URL.Path
+	path := h.getRequestURLPath(req)
 	resourceNames, err := h.ingressCache.Get(host, path)
 	if err != nil {
 		return "", nil, errors.New("Failed to get resource names from ingress cache")
@@ -269,4 +269,11 @@ func (h *Handler) URLBadParse(resourceName string, err error) int {
 		"resourceName", resourceName,
 		"err", errors.GetErrorStackString(err, 10))
 	return http.StatusBadRequest
+}
+
+func (h *Handler) getRequestURLPath(req *http.Request) string {
+	if req.URL != nil {
+		return req.URL.Path
+	}
+	return ""
 }

--- a/pkg/dlx/handler.go
+++ b/pkg/dlx/handler.go
@@ -193,7 +193,7 @@ func (h *Handler) getValuesFromCache(req *http.Request) (string, []string, error
 	path := req.URL.Path
 	resourceNames, err := h.ingressCache.Get(host, path)
 	if err != nil {
-		return "", nil, errors.New("Failed to get resourceNames from ingress cache")
+		return "", nil, errors.New("Failed to get resource names from ingress cache")
 	}
 
 	if len(resourceNames) == 0 {

--- a/pkg/dlx/handler_test.go
+++ b/pkg/dlx/handler_test.go
@@ -1,0 +1,264 @@
+package dlx
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/v3io/scaler/pkg/ingresscache"
+	resourcescalerMock "github.com/v3io/scaler/pkg/resourcescaler/mock"
+	"github.com/v3io/scaler/pkg/scalertypes"
+
+	"github.com/nuclio/logger"
+	nucliozap "github.com/nuclio/zap"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+type HandlerTestSuite struct {
+	suite.Suite
+	logger      logger.Logger
+	starter     *ResourceStarter
+	scaler      *resourcescalerMock.ResourceScaler
+	httpServer  *httptest.Server
+	backendHost string
+	backendPort int
+}
+
+type ingressValue struct {
+	host    string
+	path    string
+	targets []string
+}
+
+func (suite *HandlerTestSuite) SetupSuite() {
+	var err error
+	suite.logger, err = nucliozap.NewNuclioZapTest("test")
+	suite.Require().NoError(err)
+}
+
+func (suite *HandlerTestSuite) SetupTest() {
+	suite.scaler = &resourcescalerMock.ResourceScaler{}
+	suite.starter = &ResourceStarter{
+		logger:                   suite.logger,
+		scaler:                   suite.scaler,
+		resourceReadinessTimeout: 3 * time.Second,
+	}
+	allowedPaths := map[string]struct{}{
+		// TODO - To fix this test for a valid path (i.e.- '/test/path'), the path suffix needs to be removed from h.parseTargetURL
+		"//test/path/test/path":                         {},
+		"//test/path/to/multiple/test/path/to/multiple": {},
+	}
+	// Start a test server that always returns 200
+	suite.httpServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, exists := allowedPaths[r.URL.Path]; exists {
+			w.WriteHeader(http.StatusOK)
+		} else {
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+
+	backendURL, _ := url.Parse(suite.httpServer.URL)
+	suite.backendHost = backendURL.Hostname()
+	backendPort := backendURL.Port()
+	if backendPort == "" {
+		backendPort = "8080" // Default HTTP port
+	}
+	backendPortInt, err := strconv.Atoi(backendPort)
+	suite.Require().NoError(err)
+	suite.backendPort = backendPortInt
+}
+
+func (suite *HandlerTestSuite) TearDownTest() {
+	if suite.httpServer != nil {
+		suite.httpServer.Close()
+	}
+}
+
+func (suite *HandlerTestSuite) TestHandleRequest() {
+	for _, tc := range []struct {
+		name                  string
+		resolveServiceNameErr error
+		initialCachedData     *ingressValue
+		reqHeaders            map[string]string
+		reqHost               string
+		reqPath               string
+		expectedStatus        int
+	}{
+		{
+			name:                  "No ingress headers, host and path found in ingress cache",
+			resolveServiceNameErr: nil,
+			initialCachedData: &ingressValue{
+				host:    "www.example.com",
+				path:    "/test/path",
+				targets: []string{"test-targets-name-1"},
+			},
+			reqHost:        "www.example.com",
+			reqPath:        "/test/path",
+			expectedStatus: http.StatusOK,
+		}, {
+			name:                  "No ingress headers,multiple targets found in ingress cache",
+			resolveServiceNameErr: nil,
+			initialCachedData: &ingressValue{
+				host:    "www.example.com",
+				path:    "/test/path/to/multiple",
+				targets: []string{"test-targets-name-1", "test-targets-name-2"},
+			},
+			reqHost:        "www.example.com",
+			reqPath:        "/test/path/to/multiple",
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:                  "No ingress headers, not found in ingress cache",
+			resolveServiceNameErr: nil,
+			initialCachedData:     nil,
+			reqHost:               "unknown",
+			reqPath:               "/notfound",
+			expectedStatus:        http.StatusBadRequest,
+		},
+		{
+			name:                  "No ingress headers, scaler fails",
+			resolveServiceNameErr: errors.New("fail"),
+			initialCachedData: &ingressValue{
+				host:    "www.example.com",
+				path:    "/test/path",
+				targets: []string{"test-targets-name-1"},
+			},
+			reqHost:        "www.example.com",
+			reqPath:        "/test/path",
+			expectedStatus: http.StatusInternalServerError,
+		},
+	} {
+		suite.Run(tc.name, func() {
+			// test case setup
+			suite.scaler.ExpectedCalls = nil
+			suite.scaler.On("ResolveServiceName", mock.Anything).Return(suite.backendHost, tc.resolveServiceNameErr)
+			suite.scaler.On("SetScaleCtx", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			testIngressCache := ingresscache.NewIngressCache(suite.logger)
+			if tc.initialCachedData != nil {
+				err := testIngressCache.Set(tc.initialCachedData.host, tc.initialCachedData.path, tc.initialCachedData.targets)
+				suite.Require().NoError(err)
+			}
+
+			testHandler := suite.createTestHandler(suite.backendPort, testIngressCache)
+			testRequest := suite.createTestHTTPRequest(tc.reqHeaders, tc.reqHost, tc.reqPath)
+			testResponse := httptest.NewRecorder()
+
+			// call the testHandler
+			testHandler.handleRequest(testResponse, testRequest)
+
+			// validate the response
+			suite.Require().Equal(tc.expectedStatus, testResponse.Code)
+			suite.scaler.AssertExpectations(suite.T())
+		})
+	}
+}
+
+func (suite *HandlerTestSuite) TestGetResourceNameAndPath() {
+	for _, tc := range []struct {
+		name                  string
+		errMsg                string
+		initialCachedData     *ingressValue
+		reqHeaders            map[string]string
+		reqHost               string
+		reqPath               string
+		expectErr             bool
+		expectedPath          string
+		expectedResourceNames []string
+	}{
+		{
+			name: "No ingress headers, host and path found in ingress cache",
+			initialCachedData: &ingressValue{
+				host:    "www.example.com",
+				path:    "/test/path",
+				targets: []string{"test-targets-name-1"},
+			},
+			reqHost:               "www.example.com",
+			reqPath:               "/test/path",
+			expectedPath:          "/test/path",
+			expectedResourceNames: []string{"test-targets-name-1"},
+		}, {
+			name:                  "Ingress headers, host and path did not found in ingress cache",
+			reqHost:               "www.example.com",
+			reqPath:               "/test/path",
+			expectedPath:          "/test/path",
+			expectedResourceNames: []string{"test-targets-name-1"},
+			reqHeaders: map[string]string{
+				"X-Resource-Name": "test-targets-name-1",
+				"X-Resource-Path": "/test/path",
+			},
+		}, {
+			name:      "Missing both ingress headers and host and path did not found in ingress cache",
+			reqHost:   "www.example.com",
+			reqPath:   "/test/path",
+			expectErr: true,
+			errMsg:    "No target name header found",
+		},
+	} {
+		suite.Run(tc.name, func() {
+			// test case setup
+			testIngressCache := ingresscache.NewIngressCache(suite.logger)
+			if tc.initialCachedData != nil {
+				err := testIngressCache.Set(tc.initialCachedData.host, tc.initialCachedData.path, tc.initialCachedData.targets)
+				suite.Require().NoError(err)
+			}
+
+			testHandler := suite.createTestHandler(suite.backendPort, testIngressCache)
+			testRequest := suite.createTestHTTPRequest(tc.reqHeaders, tc.reqHost, tc.reqPath)
+			resultPath, resultResourceNames, err := testHandler.getResourceNameAndPath(testRequest)
+
+			// validate the result
+			if tc.expectErr {
+				suite.Require().Error(err)
+				suite.Require().ErrorContains(err, tc.errMsg)
+			} else {
+				suite.Require().NoError(err)
+				suite.Require().Equal(tc.expectedPath, resultPath)
+				suite.Require().Equal(tc.expectedResourceNames, resultResourceNames)
+			}
+		})
+	}
+}
+
+// --- HandlerTestSuite suite methods ---
+
+func (suite *HandlerTestSuite) createTestHandler(targetPort int, cache ingresscache.IngressHostCacheReader) Handler {
+	handler, err := NewHandler(
+		suite.logger,
+		suite.starter,
+		suite.scaler,
+		"X-Resource-Name",
+		"X-Resource-Path",
+		targetPort,
+		scalertypes.MultiTargetStrategyPrimary,
+		cache,
+	)
+	suite.Require().NoError(err)
+	return handler
+}
+
+func (suite *HandlerTestSuite) createTestHTTPRequest(
+	reqHeaders map[string]string,
+	reqHost string,
+	reqPath string,
+) *http.Request {
+	req := httptest.NewRequest("GET", "/", nil)
+	if reqHost != "" {
+		req.Host = reqHost
+	}
+	if reqPath != "" {
+		req.URL.Path = reqPath
+	}
+	for k, v := range reqHeaders {
+		req.Header.Set(k, v)
+	}
+	return req
+}
+
+func TestHandlerTestSuite(t *testing.T) {
+	suite.Run(t, new(HandlerTestSuite))
+}

--- a/pkg/dlx/handler_test.go
+++ b/pkg/dlx/handler_test.go
@@ -153,7 +153,7 @@ func (suite *HandlerTestSuite) TestHandleRequest() {
 	}
 }
 
-func (suite *HandlerTestSuite) TestGetResourceNameAndPath() {
+func (suite *HandlerTestSuite) TestGetPathAndResourceNames() {
 	for _, tc := range []struct {
 		name                  string
 		errMsg                string
@@ -204,7 +204,7 @@ func (suite *HandlerTestSuite) TestGetResourceNameAndPath() {
 
 			testHandler := suite.createTestHandler(suite.backendPort, testIngressCache)
 			testRequest := suite.createTestHTTPRequest(tc.reqHeaders, tc.reqHost, tc.reqPath)
-			resultPath, resultResourceNames, err := testHandler.getResourceNameAndPath(testRequest)
+			resultPath, resultResourceNames, err := testHandler.getPathAndResourceNames(testRequest)
 
 			// validate the result
 			if tc.expectErr {

--- a/pkg/dlx/handler_test.go
+++ b/pkg/dlx/handler_test.go
@@ -44,7 +44,6 @@ func (suite *HandlerTestSuite) SetupTest() {
 		resourceReadinessTimeout: 3 * time.Second,
 	}
 	allowedPaths := map[string]struct{}{
-		// TODO - To fix this test for a valid path (i.e.- '/test/path'), the path suffix needs to be removed from h.parseTargetURL
 		"/test/path/test/path":                         {},
 		"/test/path/to/multiple/test/path/to/multiple": {},
 	}

--- a/pkg/dlx/handler_test.go
+++ b/pkg/dlx/handler_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/v3io/scaler/pkg/ingresscache"
+	"github.com/v3io/scaler/pkg/kube"
 	resourcescalerMock "github.com/v3io/scaler/pkg/resourcescaler/mock"
 	"github.com/v3io/scaler/pkg/scalertypes"
 
@@ -27,12 +28,6 @@ type HandlerTestSuite struct {
 	httpServer  *httptest.Server
 	backendHost string
 	backendPort int
-}
-
-type ingressValue struct {
-	host    string
-	path    string
-	targets []string
 }
 
 func (suite *HandlerTestSuite) SetupSuite() {
@@ -83,7 +78,7 @@ func (suite *HandlerTestSuite) TestHandleRequest() {
 	for _, tc := range []struct {
 		name                  string
 		resolveServiceNameErr error
-		initialCachedData     *ingressValue
+		initialCachedData     *kube.IngressValue
 		reqHeaders            map[string]string
 		reqHost               string
 		reqPath               string
@@ -92,10 +87,10 @@ func (suite *HandlerTestSuite) TestHandleRequest() {
 		{
 			name:                  "No ingress headers, host and path found in ingress cache",
 			resolveServiceNameErr: nil,
-			initialCachedData: &ingressValue{
-				host:    "www.example.com",
-				path:    "/test/path",
-				targets: []string{"test-targets-name-1"},
+			initialCachedData: &kube.IngressValue{
+				Host:    "www.example.com",
+				Path:    "/test/path",
+				Targets: []string{"test-targets-name-1"},
 			},
 			reqHost:        "www.example.com",
 			reqPath:        "/test/path",
@@ -103,10 +98,10 @@ func (suite *HandlerTestSuite) TestHandleRequest() {
 		}, {
 			name:                  "No ingress headers,multiple targets found in ingress cache",
 			resolveServiceNameErr: nil,
-			initialCachedData: &ingressValue{
-				host:    "www.example.com",
-				path:    "/test/path/to/multiple",
-				targets: []string{"test-targets-name-1", "test-targets-name-2"},
+			initialCachedData: &kube.IngressValue{
+				Host:    "www.example.com",
+				Path:    "/test/path/to/multiple",
+				Targets: []string{"test-targets-name-1", "test-targets-name-2"},
 			},
 			reqHost:        "www.example.com",
 			reqPath:        "/test/path/to/multiple",
@@ -123,10 +118,10 @@ func (suite *HandlerTestSuite) TestHandleRequest() {
 		{
 			name:                  "No ingress headers, scaler fails",
 			resolveServiceNameErr: errors.New("fail"),
-			initialCachedData: &ingressValue{
-				host:    "www.example.com",
-				path:    "/test/path",
-				targets: []string{"test-targets-name-1"},
+			initialCachedData: &kube.IngressValue{
+				Host:    "www.example.com",
+				Path:    "/test/path",
+				Targets: []string{"test-targets-name-1"},
 			},
 			reqHost:        "www.example.com",
 			reqPath:        "/test/path",
@@ -140,7 +135,7 @@ func (suite *HandlerTestSuite) TestHandleRequest() {
 			suite.scaler.On("SetScaleCtx", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			testIngressCache := ingresscache.NewIngressCache(suite.logger)
 			if tc.initialCachedData != nil {
-				err := testIngressCache.Set(tc.initialCachedData.host, tc.initialCachedData.path, tc.initialCachedData.targets)
+				err := testIngressCache.Set(tc.initialCachedData.Host, tc.initialCachedData.Path, tc.initialCachedData.Targets)
 				suite.Require().NoError(err)
 			}
 
@@ -162,7 +157,7 @@ func (suite *HandlerTestSuite) TestGetResourceNameAndPath() {
 	for _, tc := range []struct {
 		name                  string
 		errMsg                string
-		initialCachedData     *ingressValue
+		initialCachedData     *kube.IngressValue
 		reqHeaders            map[string]string
 		reqHost               string
 		reqPath               string
@@ -172,10 +167,10 @@ func (suite *HandlerTestSuite) TestGetResourceNameAndPath() {
 	}{
 		{
 			name: "No ingress headers, host and path found in ingress cache",
-			initialCachedData: &ingressValue{
-				host:    "www.example.com",
-				path:    "/test/path",
-				targets: []string{"test-targets-name-1"},
+			initialCachedData: &kube.IngressValue{
+				Host:    "www.example.com",
+				Path:    "/test/path",
+				Targets: []string{"test-targets-name-1"},
 			},
 			reqHost:               "www.example.com",
 			reqPath:               "/test/path",
@@ -203,7 +198,7 @@ func (suite *HandlerTestSuite) TestGetResourceNameAndPath() {
 			// test case setup
 			testIngressCache := ingresscache.NewIngressCache(suite.logger)
 			if tc.initialCachedData != nil {
-				err := testIngressCache.Set(tc.initialCachedData.host, tc.initialCachedData.path, tc.initialCachedData.targets)
+				err := testIngressCache.Set(tc.initialCachedData.Host, tc.initialCachedData.Path, tc.initialCachedData.Targets)
 				suite.Require().NoError(err)
 			}
 

--- a/pkg/kube/ingress.go
+++ b/pkg/kube/ingress.go
@@ -35,11 +35,11 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-type ingressValue struct {
-	name    string
-	host    string
-	path    string
-	targets []string
+type IngressValue struct {
+	Name    string
+	Host    string
+	Path    string
+	Targets []string
 }
 
 // IngressWatcher watches for changes in Kubernetes Ingress resources and updates the ingress cache accordingly
@@ -133,22 +133,22 @@ func (iw *IngressWatcher) AddHandler(obj interface{}) {
 		return
 	}
 
-	if err := iw.cache.Set(ingress.host, ingress.path, ingress.targets); err != nil {
+	if err := iw.cache.Set(ingress.Host, ingress.Path, ingress.Targets); err != nil {
 		iw.logger.WarnWith("Add ingress handler failure - failed to add the new value to ingress cache",
 			"error", err.Error(),
 			"object", obj,
-			"ingressName", ingress.name,
-			"host", ingress.host,
-			"path", ingress.path,
-			"targets", ingress.targets)
+			"ingressName", ingress.Name,
+			"host", ingress.Host,
+			"path", ingress.Path,
+			"targets", ingress.Targets)
 		return
 	}
 
 	iw.logger.DebugWith("Add ingress handler - successfully added ingress to cache",
-		"ingressName", ingress.name,
-		"host", ingress.host,
-		"path", ingress.path,
-		"targets", ingress.targets)
+		"ingressName", ingress.Name,
+		"host", ingress.Host,
+		"path", ingress.Path,
+		"targets", ingress.Targets)
 }
 
 func (iw *IngressWatcher) UpdateHandler(oldObj, newObj interface{}) {
@@ -187,34 +187,34 @@ func (iw *IngressWatcher) UpdateHandler(oldObj, newObj interface{}) {
 	}
 
 	// if the host or path has changed, we need to delete the old entry
-	if oldIngress.host != newIngress.host || oldIngress.path != newIngress.path {
-		if err := iw.cache.Delete(oldIngress.host, oldIngress.path, oldIngress.targets); err != nil {
+	if oldIngress.Host != newIngress.Host || oldIngress.Path != newIngress.Path {
+		if err := iw.cache.Delete(oldIngress.Host, oldIngress.Path, oldIngress.Targets); err != nil {
 			iw.logger.WarnWith("Update ingress handler failure - failed to delete old ingress",
 				"error", err.Error(),
-				"ingressName", oldIngress.name,
+				"ingressName", oldIngress.Name,
 				"object", oldObj,
-				"host", oldIngress.host,
-				"path", oldIngress.path,
-				"targets", oldIngress.targets)
+				"host", oldIngress.Host,
+				"path", oldIngress.Path,
+				"targets", oldIngress.Targets)
 		}
 	}
 
-	if err := iw.cache.Set(newIngress.host, newIngress.path, newIngress.targets); err != nil {
+	if err := iw.cache.Set(newIngress.Host, newIngress.Path, newIngress.Targets); err != nil {
 		iw.logger.WarnWith("Update ingress handler failure - failed to add the new value",
 			"error", err.Error(),
 			"object", newObj,
-			"ingressName", newIngress.name,
-			"host", newIngress.host,
-			"path", newIngress.path,
-			"targets", newIngress.targets)
+			"ingressName", newIngress.Name,
+			"host", newIngress.Host,
+			"path", newIngress.Path,
+			"targets", newIngress.Targets)
 		return
 	}
 
 	iw.logger.DebugWith("Update ingress handler - successfully updated ingress in cache",
-		"ingressName", newIngress.name,
-		"host", newIngress.host,
-		"path", newIngress.path,
-		"targets", newIngress.targets)
+		"ingressName", newIngress.Name,
+		"host", newIngress.Host,
+		"path", newIngress.Path,
+		"targets", newIngress.Targets)
 }
 
 func (iw *IngressWatcher) DeleteHandler(obj interface{}) {
@@ -225,28 +225,28 @@ func (iw *IngressWatcher) DeleteHandler(obj interface{}) {
 		return
 	}
 
-	if err := iw.cache.Delete(ingress.host, ingress.path, ingress.targets); err != nil {
+	if err := iw.cache.Delete(ingress.Host, ingress.Path, ingress.Targets); err != nil {
 		iw.logger.WarnWith("Delete ingress handler failure - failed delete from cache",
 			"error", err.Error(),
 			"object", obj,
-			"ingressName", ingress.name,
-			"host", ingress.host,
-			"path", ingress.path,
-			"targets", ingress.targets)
+			"ingressName", ingress.Name,
+			"host", ingress.Host,
+			"path", ingress.Path,
+			"targets", ingress.Targets)
 		return
 	}
 
 	iw.logger.DebugWith("Delete ingress handler - successfully deleted ingress from cache",
-		"ingressName", ingress.name,
-		"host", ingress.host,
-		"path", ingress.path,
-		"targets", ingress.targets)
+		"ingressName", ingress.Name,
+		"host", ingress.Host,
+		"path", ingress.Path,
+		"targets", ingress.Targets)
 }
 
 // --- internal methods ---
 
 // extractValuesFromIngressResource extracts the relevant values from a Kubernetes Ingress resource
-func (iw *IngressWatcher) extractValuesFromIngressResource(obj interface{}) (*ingressValue, error) {
+func (iw *IngressWatcher) extractValuesFromIngressResource(obj interface{}) (*IngressValue, error) {
 	ingress, ok := obj.(*networkingv1.Ingress)
 	if !ok {
 		return nil, errors.New("Failed to cast object to Ingress")
@@ -271,11 +271,11 @@ func (iw *IngressWatcher) extractValuesFromIngressResource(obj interface{}) (*in
 		return nil, errors.Wrap(err, "Failed to extract path from ingress")
 	}
 
-	return &ingressValue{
-		host:    host,
-		path:    path,
-		targets: targets,
-		name:    ingress.Name,
+	return &IngressValue{
+		Host:    host,
+		Path:    path,
+		Targets: targets,
+		Name:    ingress.Name,
 	}, nil
 }
 

--- a/pkg/kube/ingress_test.go
+++ b/pkg/kube/ingress_test.go
@@ -64,47 +64,47 @@ func (suite *IngressWatcherTestSuite) SetupTest() {
 func (suite *IngressWatcherTestSuite) TestAddHandler() {
 	for _, testCase := range []struct {
 		name              string
-		testArgs          ingressValue
+		testArgs          IngressValue
 		expectedResult    []string
-		initialCachedData *ingressValue
+		initialCachedData *IngressValue
 		errorMessage      string
 		expectError       bool
 	}{
 		{
 			name: "Add PairTarget",
-			testArgs: ingressValue{
-				host:    "www.example.com",
-				path:    "/test/path",
-				targets: []string{"test-targets-name-1", "test-targets-name-2"},
+			testArgs: IngressValue{
+				Host:    "www.example.com",
+				Path:    "/test/path",
+				Targets: []string{"test-targets-name-1", "test-targets-name-2"},
 			},
 			expectedResult: []string{"test-targets-name-1", "test-targets-name-2"},
 		}, {
 			name: "Add SingleTarget",
-			testArgs: ingressValue{
-				host:    "www.example.com",
-				path:    "/test/path",
-				targets: []string{"test-targets-name-1"},
+			testArgs: IngressValue{
+				Host:    "www.example.com",
+				Path:    "/test/path",
+				Targets: []string{"test-targets-name-1"},
 			},
 			expectedResult: []string{"test-targets-name-1"},
 		}, {
 			name: "Add SingleTarget with different name to the same host and path",
-			testArgs: ingressValue{
-				host:    "www.example.com",
-				path:    "/test/path",
-				targets: []string{"test-targets-name-2"},
+			testArgs: IngressValue{
+				Host:    "www.example.com",
+				Path:    "/test/path",
+				Targets: []string{"test-targets-name-2"},
 			},
 			expectedResult: []string{"test-targets-name-2"},
-			initialCachedData: &ingressValue{
-				host:    "www.example.com",
-				path:    "/test/path",
-				targets: []string{"test-targets-name-1"},
+			initialCachedData: &IngressValue{
+				Host:    "www.example.com",
+				Path:    "/test/path",
+				Targets: []string{"test-targets-name-1"},
 			},
 		}, {
 			name: "bad input- should fail",
-			testArgs: ingressValue{
-				host:    "www.example.com",
-				path:    "/test/path",
-				targets: []string{"test-targets-name-2"},
+			testArgs: IngressValue{
+				Host:    "www.example.com",
+				Path:    "/test/path",
+				Targets: []string{"test-targets-name-2"},
 			},
 			expectedResult: []string{},
 			expectError:    true,
@@ -116,20 +116,20 @@ func (suite *IngressWatcherTestSuite) TestAddHandler() {
 			testIngressWatcher, err := suite.createTestIngressWatcher()
 			suite.Require().NoError(err)
 
-			testObj = suite.createDummyIngress(testCase.testArgs.host, testCase.testArgs.path, "1", testCase.testArgs.targets)
+			testObj = suite.createDummyIngress(testCase.testArgs.Host, testCase.testArgs.Path, "1", testCase.testArgs.Targets)
 
 			if testCase.expectError {
 				testObj = &networkingv1.IngressSpec{}
 			}
 
 			if testCase.initialCachedData != nil {
-				err = testIngressWatcher.cache.Set(testCase.initialCachedData.host, testCase.initialCachedData.path, testCase.initialCachedData.targets)
+				err = testIngressWatcher.cache.Set(testCase.initialCachedData.Host, testCase.initialCachedData.Path, testCase.initialCachedData.Targets)
 				suite.Require().NoError(err)
 			}
 
 			testIngressWatcher.AddHandler(testObj)
 			// get the targets from the cache and compare values
-			resultTargetNames, err := testIngressWatcher.cache.Get(testCase.testArgs.host, testCase.testArgs.path)
+			resultTargetNames, err := testIngressWatcher.cache.Get(testCase.testArgs.Host, testCase.testArgs.Path)
 			if testCase.expectError {
 				suite.Require().Error(err)
 				suite.Require().ErrorContains(err, testCase.errorMessage)
@@ -146,9 +146,9 @@ func (suite *IngressWatcherTestSuite) TestUpdateHandler() {
 	for _, testCase := range []struct {
 		name              string
 		expectedResults   []expectedResult
-		initialCachedData *ingressValue
-		testOldObj        ingressValue
-		testNewObj        ingressValue
+		initialCachedData *IngressValue
+		testOldObj        IngressValue
+		testNewObj        IngressValue
 		OldObjVersion     string
 		newObjVersion     string
 	}{
@@ -161,22 +161,22 @@ func (suite *IngressWatcherTestSuite) TestUpdateHandler() {
 					targets: []string{"test-targets-name-1", "test-targets-name-3"},
 				},
 			},
-			testOldObj: ingressValue{
-				host:    "www.example.com",
-				path:    "/test/path",
-				targets: []string{"test-targets-name-1", "test-targets-name-2"},
+			testOldObj: IngressValue{
+				Host:    "www.example.com",
+				Path:    "/test/path",
+				Targets: []string{"test-targets-name-1", "test-targets-name-2"},
 			},
 			OldObjVersion: "1",
-			testNewObj: ingressValue{
-				host:    "www.example.com",
-				path:    "/test/path",
-				targets: []string{"test-targets-name-1", "test-targets-name-3"},
+			testNewObj: IngressValue{
+				Host:    "www.example.com",
+				Path:    "/test/path",
+				Targets: []string{"test-targets-name-1", "test-targets-name-3"},
 			},
 			newObjVersion: "2",
-			initialCachedData: &ingressValue{
-				host:    "www.example.com",
-				path:    "/test/path",
-				targets: []string{"test-targets-name-1", "test-targets-name-2"},
+			initialCachedData: &IngressValue{
+				Host:    "www.example.com",
+				Path:    "/test/path",
+				Targets: []string{"test-targets-name-1", "test-targets-name-2"},
 			},
 		}, {
 			name: "Update PairTarget - same ResourceVersion, no change in targets",
@@ -187,40 +187,40 @@ func (suite *IngressWatcherTestSuite) TestUpdateHandler() {
 					targets: []string{"test-targets-name-1", "test-targets-name-2"},
 				},
 			},
-			testOldObj: ingressValue{
-				host:    "www.example.com",
-				path:    "/test/path",
-				targets: []string{"test-targets-name-1", "test-targets-name-2"},
+			testOldObj: IngressValue{
+				Host:    "www.example.com",
+				Path:    "/test/path",
+				Targets: []string{"test-targets-name-1", "test-targets-name-2"},
 			},
-			testNewObj: ingressValue{
-				host:    "www.example.com",
-				path:    "/test/path",
-				targets: []string{"test-targets-name-1", "test-targets-name-3"},
+			testNewObj: IngressValue{
+				Host:    "www.example.com",
+				Path:    "/test/path",
+				Targets: []string{"test-targets-name-1", "test-targets-name-3"},
 			},
 			OldObjVersion: "1",
 			newObjVersion: "1",
-			initialCachedData: &ingressValue{
-				host:    "www.example.com",
-				path:    "/test/path",
-				targets: []string{"test-targets-name-1", "test-targets-name-2"},
+			initialCachedData: &IngressValue{
+				Host:    "www.example.com",
+				Path:    "/test/path",
+				Targets: []string{"test-targets-name-1", "test-targets-name-2"},
 			},
 		}, {
 			name: "Update PairTarget - different path- should Delete old targets",
-			initialCachedData: &ingressValue{
-				host:    "www.example.com",
-				path:    "/test/path",
-				targets: []string{"test-targets-name-1", "test-targets-name-2"},
+			initialCachedData: &IngressValue{
+				Host:    "www.example.com",
+				Path:    "/test/path",
+				Targets: []string{"test-targets-name-1", "test-targets-name-2"},
 			},
-			testOldObj: ingressValue{
-				host:    "www.example.com",
-				path:    "/test/path",
-				targets: []string{"test-targets-name-1", "test-targets-name-2"},
+			testOldObj: IngressValue{
+				Host:    "www.example.com",
+				Path:    "/test/path",
+				Targets: []string{"test-targets-name-1", "test-targets-name-2"},
 			},
 			OldObjVersion: "1",
-			testNewObj: ingressValue{
-				host:    "www.example.com",
-				path:    "/another/path",
-				targets: []string{"test-targets-name-1", "test-targets-name-2"},
+			testNewObj: IngressValue{
+				Host:    "www.example.com",
+				Path:    "/another/path",
+				Targets: []string{"test-targets-name-1", "test-targets-name-2"},
 			},
 			newObjVersion: "2",
 			expectedResults: []expectedResult{
@@ -237,21 +237,21 @@ func (suite *IngressWatcherTestSuite) TestUpdateHandler() {
 			},
 		}, {
 			name: "Update PairTarget - different host- should Delete old targets",
-			initialCachedData: &ingressValue{
-				host:    "www.example.com",
-				path:    "/test/path",
-				targets: []string{"test-targets-name-1", "test-targets-name-2"},
+			initialCachedData: &IngressValue{
+				Host:    "www.example.com",
+				Path:    "/test/path",
+				Targets: []string{"test-targets-name-1", "test-targets-name-2"},
 			},
-			testOldObj: ingressValue{
-				host:    "www.example.com",
-				path:    "/test/path",
-				targets: []string{"test-targets-name-1", "test-targets-name-2"},
+			testOldObj: IngressValue{
+				Host:    "www.example.com",
+				Path:    "/test/path",
+				Targets: []string{"test-targets-name-1", "test-targets-name-2"},
 			},
 			OldObjVersion: "1",
-			testNewObj: ingressValue{
-				host:    "www.google.com",
-				path:    "/test/path",
-				targets: []string{"test-targets-name-1", "test-targets-name-2"},
+			testNewObj: IngressValue{
+				Host:    "www.google.com",
+				Path:    "/test/path",
+				Targets: []string{"test-targets-name-1", "test-targets-name-2"},
 			},
 			newObjVersion: "2",
 			expectedResults: []expectedResult{
@@ -272,11 +272,11 @@ func (suite *IngressWatcherTestSuite) TestUpdateHandler() {
 			testIngressWatcher, err := suite.createTestIngressWatcher()
 			suite.Require().NoError(err)
 
-			testOldObj := suite.createDummyIngress(testCase.testOldObj.host, testCase.testOldObj.path, testCase.OldObjVersion, testCase.testOldObj.targets)
-			testNewObj := suite.createDummyIngress(testCase.testNewObj.host, testCase.testNewObj.path, testCase.newObjVersion, testCase.testNewObj.targets)
+			testOldObj := suite.createDummyIngress(testCase.testOldObj.Host, testCase.testOldObj.Path, testCase.OldObjVersion, testCase.testOldObj.Targets)
+			testNewObj := suite.createDummyIngress(testCase.testNewObj.Host, testCase.testNewObj.Path, testCase.newObjVersion, testCase.testNewObj.Targets)
 
 			if testCase.initialCachedData != nil {
-				err = testIngressWatcher.cache.Set(testCase.initialCachedData.host, testCase.initialCachedData.path, testCase.initialCachedData.targets)
+				err = testIngressWatcher.cache.Set(testCase.initialCachedData.Host, testCase.initialCachedData.Path, testCase.initialCachedData.Targets)
 				suite.Require().NoError(err)
 			}
 
@@ -301,23 +301,23 @@ func (suite *IngressWatcherTestSuite) TestUpdateHandler() {
 func (suite *IngressWatcherTestSuite) TestDeleteHandler() {
 	for _, testCase := range []struct {
 		name              string
-		testArgs          ingressValue
+		testArgs          IngressValue
 		expectedResult    expectedResult
-		initialCachedData *ingressValue
+		initialCachedData *IngressValue
 		errorMessage      string
 		expectError       bool
 	}{
 		{
 			name: "Delete PairTarget",
-			initialCachedData: &ingressValue{
-				host:    "www.example.com",
-				path:    "/test/path",
-				targets: []string{"test-targets-name-1", "test-targets-name-2"},
+			initialCachedData: &IngressValue{
+				Host:    "www.example.com",
+				Path:    "/test/path",
+				Targets: []string{"test-targets-name-1", "test-targets-name-2"},
 			},
-			testArgs: ingressValue{
-				host:    "www.example.com",
-				path:    "/test/path",
-				targets: []string{"test-targets-name-1", "test-targets-name-2"},
+			testArgs: IngressValue{
+				Host:    "www.example.com",
+				Path:    "/test/path",
+				Targets: []string{"test-targets-name-1", "test-targets-name-2"},
 			},
 			expectedResult: expectedResult{
 				host:           "www.example.com",
@@ -328,15 +328,15 @@ func (suite *IngressWatcherTestSuite) TestDeleteHandler() {
 			},
 		}, {
 			name: "Delete SingleTarget",
-			initialCachedData: &ingressValue{
-				host:    "www.example.com",
-				path:    "/test/path",
-				targets: []string{"test-targets-name-1"},
+			initialCachedData: &IngressValue{
+				Host:    "www.example.com",
+				Path:    "/test/path",
+				Targets: []string{"test-targets-name-1"},
 			},
-			testArgs: ingressValue{
-				host:    "www.example.com",
-				path:    "/test/path",
-				targets: []string{"test-targets-name-1"},
+			testArgs: IngressValue{
+				Host:    "www.example.com",
+				Path:    "/test/path",
+				Targets: []string{"test-targets-name-1"},
 			},
 			expectedResult: expectedResult{
 				host:           "www.example.com",
@@ -347,15 +347,15 @@ func (suite *IngressWatcherTestSuite) TestDeleteHandler() {
 			},
 		}, {
 			name: "bad input- should fail and keep the cache as is",
-			initialCachedData: &ingressValue{
-				host:    "www.example.com",
-				path:    "/test/path",
-				targets: []string{"test-targets-name-1"},
+			initialCachedData: &IngressValue{
+				Host:    "www.example.com",
+				Path:    "/test/path",
+				Targets: []string{"test-targets-name-1"},
 			},
-			testArgs: ingressValue{
-				host:    "www.example.com",
-				path:    "/test/path",
-				targets: []string{"test-targets-name-2"},
+			testArgs: IngressValue{
+				Host:    "www.example.com",
+				Path:    "/test/path",
+				Targets: []string{"test-targets-name-2"},
 			},
 			expectedResult: expectedResult{
 				host:    "www.example.com",
@@ -371,14 +371,14 @@ func (suite *IngressWatcherTestSuite) TestDeleteHandler() {
 			testIngressWatcher, err := suite.createTestIngressWatcher()
 			suite.Require().NoError(err)
 
-			testObj = suite.createDummyIngress(testCase.testArgs.host, testCase.testArgs.path, "1", testCase.testArgs.targets)
+			testObj = suite.createDummyIngress(testCase.testArgs.Host, testCase.testArgs.Path, "1", testCase.testArgs.Targets)
 
 			if testCase.expectError {
 				testObj = &networkingv1.IngressSpec{}
 			}
 
 			if testCase.initialCachedData != nil {
-				err = testIngressWatcher.cache.Set(testCase.initialCachedData.host, testCase.initialCachedData.path, testCase.initialCachedData.targets)
+				err = testIngressWatcher.cache.Set(testCase.initialCachedData.Host, testCase.initialCachedData.Path, testCase.initialCachedData.Targets)
 				suite.Require().NoError(err)
 			}
 


### PR DESCRIPTION
### Description  
This PR integrates the cache into the handler in order to resolve the request target based on the new cache.

### Changes Made  
- Add the `IngressHostCacheReader` (the cache read-only access) to the handler  
- Add the logic for the new resolving (i.e. - try to resolve based on the cache, and if failed - resolve by the existing headers' logic)

### Testing  
- Added a flow test - for the entire request handling  
- Added unit tests for the resolving per case (i.e. - based on headers and based on ingress)

### References  
- Jira ticket link: https://iguazio.atlassian.net/browse/NUC-523  
- External link: this PR is based on this branch - https://github.com/v3io/scaler/pull/76

### Additional Notes  
- I left a **TODO** question inside the test file — it seems that when parsing the `targetURL`, the handler appends the path twice. This fix is relatively minor and has been tested manually, but since the current code still works, it's worth deciding whether we want to address it now.