### PR TITLE
[DLX] Support root path when resolving URL

### DIFF
--- a/pkg/ingresscache/ingresscache.go
+++ b/pkg/ingresscache/ingresscache.go
@@ -100,7 +100,12 @@ func (ic *IngressCache) Get(host, path string) ([]string, error) {
 
 	result, err := ingressHostsTree.Get(path)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get the targets from the ingress host tree")
+		// If the specific path lookup fails, retry with root ("/").
+		// Needed because the trie can’t resolve prefixes when "/" is both delimiter and root path.
+		result, err = ingressHostsTree.Get("/")
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get the targets from the ingress host tree")
+		}
 	}
 
 	return result.ToSliceString(), nil

--- a/pkg/ingresscache/ingresscache_test.go
+++ b/pkg/ingresscache/ingresscache_test.go
@@ -53,6 +53,10 @@ func (suite *IngressCacheTestSuite) SetupTest() {
 
 func (suite *IngressCacheTestSuite) TestGet() {
 	suite.T().Parallel()
+	initialStatePrefixTests := []ingressCacheTestInitialState{
+		{"example.com", "/", []string{"test-target-name-1"}},
+		{"example.com", "/path/to", []string{"test-target-name-2"}},
+	}
 	for _, testCase := range []struct {
 		name           string
 		initialState   []ingressCacheTestInitialState
@@ -99,6 +103,31 @@ func (suite *IngressCacheTestSuite) TestGet() {
 			initialState: []ingressCacheTestInitialState{
 				{"example.com", "/test/path", []string{"test-target-name-1"}},
 			},
+		}, {
+			name:           "Get root path",
+			args:           testIngressCacheArgs{"example.com", "/", []string{"test-target-name-1"}},
+			expectedResult: []string{"test-target-name-1"},
+			initialState:   initialStatePrefixTests,
+		}, {
+			name:           "Get root path as closest prefix match",
+			args:           testIngressCacheArgs{"example.com", "/path", []string{"test-target-name-1"}},
+			expectedResult: []string{"test-target-name-1"},
+			initialState:   initialStatePrefixTests,
+		}, {
+			name:           "Get root path as closest prefix match with trailing slash",
+			args:           testIngressCacheArgs{"example.com", "/path/", []string{"test-target-name-1"}},
+			expectedResult: []string{"test-target-name-1"},
+			initialState:   initialStatePrefixTests,
+		}, {
+			name:           "Get path with exact match",
+			args:           testIngressCacheArgs{"example.com", "/path/to", []string{"test-target-name-2"}},
+			expectedResult: []string{"test-target-name-2"},
+			initialState:   initialStatePrefixTests,
+		}, {
+			name:           "Get closest prefix match with a longer path",
+			args:           testIngressCacheArgs{"example.com", "/path/to/another", []string{"test-target-name-2"}},
+			expectedResult: []string{"test-target-name-2"},
+			initialState:   initialStatePrefixTests,
 		},
 	} {
 		suite.Run(testCase.name, func() {


### PR DESCRIPTION
### 📝 Description
This PR handles the case where the closest common prefix of a request and the existing ingress is the root path (i.e. `\`).

---

### 🛠️ Changes Made
- Add a retry Get with the root as a path

---

### ✅ Checklist
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- Dev QA
  - Verified on my setup: a function with ingress / was successfully scaled from zero when invoked with /a/b (screenshot attached).
  - Added unit tests for all scenarios outlined in the HLD, which also validate this fix.

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/NUC-596
- Design docs links: https://iguazio.atlassian.net/wiki/spaces/PLAT/pages/372080641/DLX+decoupling+ingress-nginx+annotations+HLD#Create-in-memory-cache
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
- Nuclio should be updated once this CR will be merged and tagged

### 📸 Screenshots / Logs
<img width="1934" height="948" alt="image" src="https://github.com/user-attachments/assets/aa794829-8a6a-4e95-a413-dc5a905225a4" />
