### PR TITLE
[Dependencies] Bump Go version

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,44 +12,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+version: "2"
+
+# timeout for analysis
+timeout: 5m
 linters:
-  disable-all: true
+  default: none
   enable:
+    - errcheck
     - goconst
-    - gofmt
-    - revive
-    - gosimple
+    - gocritic
+    - govet
     - ineffassign
     - misspell
     - staticcheck
     - unconvert
     - govet
     - unused
-    - errcheck
-    - typecheck
-    - gocritic
+
+formatters:
+  enable:
     - gci
-
-run:
-
-  # timeout for analysis
-  timeout: 5m
-
-linters-settings:
-  gci:
-    sections:
-      - standard
-      - prefix(github.com/v3io/scaler)
-      - default
-      - blank
-      - dot
-
-    custom-order: true
-
-issues:
-
-  # List of regexps of issue texts to exclude
-  exclude:
-    - "comment on"
-    - "error should be the last"
-    - "should have comment"
+    - gofmt
+  settings:
+    gci:
+      sections:
+        - standard
+        - prefix(github.com/v3io/scaler)
+        - default
+        - blank
+        - dot
+      custom-order: true

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ push-docker-images:
 
 # tools get built with the specified OS/arch and inject version
 GO_BUILD_TOOL_WORKDIR = /scaler
-GOLANGCI_LINT_VERSION := v1.64.6
+GOLANGCI_LINT_VERSION := v2.7.2
 
 .PHONY: lint
 lint: modules

--- a/cmd/autoscaler/Dockerfile
+++ b/cmd/autoscaler/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-FROM gcr.io/iguazio/golang:1.23.8-alpine AS builder
+FROM gcr.io/iguazio/golang:1.25-alpine AS builder
 
 RUN apk --update --no-cache add \
     git \

--- a/cmd/dlx/Dockerfile
+++ b/cmd/dlx/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-FROM gcr.io/iguazio/golang:1.23.8-alpine AS builder
+FROM gcr.io/iguazio/golang:1.25-alpine AS builder
 
 RUN apk --update --no-cache add \
     git \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/v3io/scaler
 
-go 1.23.8
+go 1.25.5
 
 require (
 	github.com/dghubble/trie v0.1.0

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-FROM gcr.io/iguazio/golang:1.23.8
+FROM gcr.io/iguazio/golang:1.25
 
 ARG DOCKER_CLI_VERSION="28.0.4"
 


### PR DESCRIPTION
### 📝 Description
Upgrade the Go toolchain and lint configurations to newer Go versions and `golangci-lint` v2, aligning with Nuclio’s lint version and YAML structure.

---

### 🛠️ Changes Made
- Upgraded Go version to `1.25.x` across `go.mod` and all relevant Dockerfiles.
- Updated base images in the Dockerfiles.
- Upgraded **golangci-lint** from `v1.64.6` to `v2.7.2`.
- Migrated `.golangci.yml` to **v2 config format**.
- Refined linter setup:
  - Explicitly enabled a focused set of linters.
  - Moved formatting concerns (`gofmt`, `gci`) to `formatters`.
  - Removed legacy and unused configuration blocks.

---

### ✅ Checklist
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- Ran `make lint` locally with the updated golangci-lint version.
- Verified builds using updated Docker images.
- Ensured no new lint issues were introduced.

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/NUC-718
- Solves current CI failure: https://github.com/v3io/scaler/actions/runs/20998404983/job/60361313767#step:4:93

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- This is primarily a tooling and maintenance change with no runtime behavior impact
