### PR TITLE
[Prometheus metrics client] Enable empty metrics resource as output

### DIFF
--- a/pkg/autoscaler/metricsclient/prometheus.go
+++ b/pkg/autoscaler/metricsclient/prometheus.go
@@ -238,10 +238,6 @@ func (pc *PrometheusMetricsClient) getResourceMetrics(ctx context.Context, metri
 		return nil, collectorErr
 	}
 
-	if len(metricsByResource) == 0 {
-		return nil, errors.New("no metrics retrieved for any resource")
-	}
-
 	return metricsByResource, nil
 }
 

--- a/pkg/autoscaler/metricsclient/prometheus_test.go
+++ b/pkg/autoscaler/metricsclient/prometheus_test.go
@@ -223,6 +223,24 @@ func (suite *PrometheusClientTestSuite) TestGetResourceMetrics() {
 				},
 			},
 		},
+		{
+			name: "empty metrics from prometheus",
+			resources: []scalertypes.Resource{
+				{
+					Name: "test-resource1",
+					ScaleResources: []scalertypes.ScaleResource{
+						{
+							MetricName: "handled_events_total",
+							WindowSize: scalertypes.Duration{Duration: 1 * time.Minute},
+						},
+					},
+				},
+			},
+			serverResultPerWindowSize: map[string][]map[string]interface{}{
+				"1m": {},
+			},
+			expectedResult: map[string]map[string]int{},
+		},
 	}
 
 	for _, testCase := range tests {


### PR DESCRIPTION
### 📝 Description
Handling empty `metricsByResource` not as an error

---

### 🛠️ Changes Made
- Removed redundant condition in Prometheus metrics client

---

### ✅ Checklist
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- Dev test on v4 setup - tested STZ/SFZ
- Unit tests

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/NUC-742
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
By design, the scaler handles this scenario, so it is not considered an error: 
- The auto scaler will get an empty `resourcesMetricsMap` 
- The `autoScaler` checks [checkResourceToScale](https://github.com/v3io/scaler/blob/a81e869d658958c6c6b69d67ca9e068cc68376c9/pkg/autoscaler/autoscaler.go#L87C23-L87C43) 
- The `found` variable will be `false` when resourceMetricsMap is empty.
- Hence- no affect on the main flow in this case, no error is needed here.